### PR TITLE
Improve threads and crdts and singlethreadedness and rpc

### DIFF
--- a/src/p2pclient/P2PClientAutoFetcher.ts
+++ b/src/p2pclient/P2PClientAutoFetcher.ts
@@ -7,6 +7,10 @@ import {
 } from "./P2PClient";
 
 import {
+    MAX_BATCH_SIZE,
+} from "../storage/types";
+
+import {
     FetchResponse,
     StoreRequest,
     UnsubscribeRequest,
@@ -430,7 +434,7 @@ export class P2PClientAutoFetcher {
         while (images.length > 0) {
             let total = 0;
             const chunk: Buffer[] = [];
-            while (images.length > 0 && total < MESSAGE_SPLIT_BYTES) {
+            while (images.length > 0 && total < MESSAGE_SPLIT_BYTES && chunk.length < MAX_BATCH_SIZE) {
                 const image = images[0];
                 if (total + image.length > MESSAGE_SPLIT_BYTES) {
                     break;

--- a/src/p2pclient/P2PClientExtender.ts
+++ b/src/p2pclient/P2PClientExtender.ts
@@ -3,6 +3,10 @@ import {
 } from "./P2PClient";
 
 import {
+    MAX_BATCH_SIZE,
+} from "../storage/types";
+
+import {
     SendResponseFn,
 } from "./GetResponse";
 
@@ -199,7 +203,7 @@ export class P2PClientExtender extends P2PClientForwarder {
         while (images.length > 0) {
             let total = 0;
             const chunk: Buffer[] = [];
-            while (images.length > 0 && total < MESSAGE_SPLIT_BYTES) {
+            while (images.length > 0 && total < MESSAGE_SPLIT_BYTES && chunk.length < MAX_BATCH_SIZE) {
                 const image = images[0];
                 if (total + image.length > MESSAGE_SPLIT_BYTES) {
                     break;

--- a/src/rpc/APIHandshakeFactoryRPCServer.ts
+++ b/src/rpc/APIHandshakeFactoryRPCServer.ts
@@ -153,6 +153,14 @@ export class APIHandshakeFactoryRPCServer extends APIHandshakeFactory {
         });
     }
 
+    public close() {
+        this.rpc.close();
+
+        super.close();
+
+        this.rpcServers.map( o => o.rpcServer?.close() );
+    }
+
     protected getRPCServerByClient(client: ClientInterface): RPCServer {
         const socket = this.rpcServers.find( socket => socket.client === client );
 

--- a/src/rpc/AuthFactoryRPCServer.ts
+++ b/src/rpc/AuthFactoryRPCServer.ts
@@ -193,6 +193,8 @@ export class AuthFactoryRPCServer {
     }
 
     public close() {
+        this.rpc.close();
+
         this.handshakeFactories.forEach( handshakeFactoryRPCServer =>
             handshakeFactoryRPCServer.close() );
         this.handshakeFactories.length = 0;

--- a/src/rpc/HandshakeFactoryRPCServer.ts
+++ b/src/rpc/HandshakeFactoryRPCServer.ts
@@ -147,6 +147,14 @@ export class HandshakeFactoryRPCServer extends HandshakeFactory {
         });
     }
 
+    public close() {
+        this.rpc.close();
+
+        super.close();
+
+        this.rpcServers.map( o => o.rpcServer?.close() );
+    }
+
     protected getRPCServerByClient(client: ClientInterface): RPCServer {
         const socket = this.rpcServers.find( socket => socket.client === client );
 

--- a/src/rpc/OpenOdin.ts
+++ b/src/rpc/OpenOdin.ts
@@ -39,136 +39,318 @@ import {
 
 declare const window: any;
 
+/**
+ * OpenOdin is used in a browser application to authenticate with the Datawallet browser extension.
+ *
+ * It's job is to facilitate the authentication and finally pass an initiated
+ * Service instance on the onAuth() event handler.
+ *
+ * The Service instance passed on the onAuth handler is inititated but not started, the app will need
+ * to call service.start() itself when it desires to do so.
+ *
+ * However if waiting for too long to do so the Datawallet extension might get unloaded by the
+ * browser because it is idle.
+ * If that happens the OpenOdin instance's onClose handler will be called and the Service instance
+ * will not be startable anymore. In such case the application will need to created a new OpenOdin
+ * instance to start over with the authorization.
+ *
+ * After an OpenOdin instance is closed or failed authorization (which closes it) it cannot be reused.
+ */
 export class OpenOdin {
     protected rpc: RPC;
-    protected _isActive: boolean = false;
-    protected _onActive?: () => void;
-    protected signatureOffloader?: SignatureOffloaderInterface;
-    protected authFactory?: AuthFactoryInterface;
-    protected walletConf?: WalletConf;
+    protected _onOpen?: () => void;
+    protected _onAuth?: (service: Service) => void;
+    protected _onAuthFail?: (error: string) => void;
+    protected _onClose?: () => void;
+
+    protected _isClosed: boolean = false;
+    protected _isOpen: boolean = false;
     protected pendingAuth: boolean = false;
 
-    constructor(rpc?: RPC) {
-        if (!rpc) {
-            const postMessage = (message: any) => {
-                window.postMessage({message, direction: "from-page-script"}, "*");
-            };
+    protected signatureOffloader?: SignatureOffloaderInterface;
+    protected authFactory?: AuthFactoryInterface;
+    protected service?: Service;
+    protected walletConf?: WalletConf;
 
-            const listenMessage = (listener: any) => {
-                window.addEventListener("message", (event: any) => {
-                    if (event.source === window && event?.data?.direction === "from-content-script") {
-                        listener(event.data.message);
-                    }
-                    else if (event.source === window && event?.data?.direction === "from-content-script-init") {
-                        this.sendHello();
-                    }
-                });
-            };
+    /**
+     * @param appConf the application configuration to init the Service instance with.
+     * The conf will be sent to the Datawallet when authing for verbosity and potential
+     * reconfiguration by the user.
+     *
+     * @param autoAuth if set then automatically called auth() when extension allows authentication.
+     * Default is true.
+     */
+    constructor(protected appConf: ApplicationConf, protected autoAuth: boolean = true) {
+        const rpcId = Buffer.from(crypto.randomBytes(8)).toString("hex");
 
-            const rpcId = Buffer.from(crypto.randomBytes(8)).toString("hex");
+        const postMessage2 = (message: any) => {
+            postMessage({message, direction: "openodin-page-script-message"}, "*");
+        };
 
-            this.rpc = new RPC(postMessage, listenMessage, rpcId);
-        }
-        else {
-            this.rpc = rpc;
-        }
+        addEventListener("message", (event: any) => {
+            // Make sure the event comes from this window, as the content-script has the same)
+            // window object.
+            //
+            if (event.source !== window) {
+                // NOTE: see if we can use CustomEvent to narrow it down even more.
+                //
+                return;
+            }
 
-        // In case the from-content-script-init has already been sent we send hello to activate.
-        this.sendHello();
+            if (event?.data?.direction === "openodin-content-script-open") {
+                // Extension has been opened.
+                //
+                this.handleOpen();
+            }
+            else if (event?.data?.direction === "openodin-content-script-port-closed") {
+                // Port to background script closed.
+                //
+                const rpcId2 = event?.data?.message?.rpcId;
+
+                rpcId2 === rpcId && this.handleClose();
+            }
+        });
+
+        const listenMessage = (listener: any) => {
+            addEventListener("message", (event: any) => {
+                // Make sure the event comes from this window, as the content-script has the same)
+                // window object.
+                //
+                if (event.source !== window) {
+                    // NOTE: see if we can use CustomEvent to narrow it down even more.
+                    //
+                    return;
+                }
+
+                if (event?.data?.direction === "openodin-content-script-message") {
+                    // Incoming data from background-script to be passed to the RPC instance.
+                    //
+                    listener(event.data.message);
+                }
+            });
+        };
+
+        this.rpc = new RPC(postMessage2, listenMessage, rpcId);
     }
 
-    protected async sendHello() {
-        if (this._isActive) {
+    /**
+     * Helper function to fetch() and parse an ApplicationConf JSON file.
+     *
+     * @throws on error
+     */
+    public static async LoadAppConf(location: string): Promise<ApplicationConf> {
+        const appJSON = await (await fetch(location)).json();
+
+        const appConf = ParseUtil.ParseApplicationConf(appJSON);
+
+        return appConf;
+    }
+
+    /**
+     * Return the unique RPC id used for this OpenOdin instance.
+     */
+    public getId(): string {
+        return this.rpc.getId();
+    }
+
+    /**
+     * Handler called everytime the Datawallet is opened for the tab,
+     * technically each time the content-script is injected.
+     * If the instance is closed the event is not triggered.
+     * If autoAuth is set an auth process is initiated.
+     */
+    protected async handleOpen() {
+        if (this._isClosed) {
             return;
         }
 
-        const ret = await this.rpc.call("client-hello");
+        if (!this._isOpen) {
+            // If first time open the port to the background by sending a noop.
+            //
+            const ret = await this.rpc.call("noop");
 
-        if (ret === "server-hello") {
-            this._isActive = true;
-            this._onActive && this._onActive();
+            if (ret !== "noop") {
+                this.close();
+
+                throw new Error("Could not open port");
+            }
         }
-    }
 
-    public isActive(): boolean {
-        return this._isActive;
-    }
+        this._isOpen = true;
 
-    public isAuthed(): boolean {
-        return this.signatureOffloader !== undefined;
+        this._onOpen?.();
+
+        if (this.autoAuth && !this.pendingAuth && !this.isAuthed()) {
+            this.auth();
+        }
     }
 
     /**
-     * @throws on error
+     * Triggers onAuth(Service) on successful auth, or onAuthFail(error) on failed auth.
+     * In case of failed auth check isClosed() before attempting to reuse the OpenOdin instance.
+     *
+     * @throws if cannot be reused for auth, if port is closed, already authed or pending auth.
      */
-    public async auth(): Promise<void> {
-        this.pendingAuth = true;
-
-        const authResponse = await this.rpc.call("auth") as AuthResponse;
-
-        this.pendingAuth = false;
-
-        if (authResponse.error || !authResponse.signatureOffloaderRPCId || !authResponse.handshakeRPCId) {
-            throw new Error(authResponse.error ?? "Unknown error");
+    public auth = async () => {
+        if (this._isClosed || this.pendingAuth || this.isAuthed()) {
+            throw new Error("Cannot reuse OpenOdin instance");
         }
 
-        const rpc1 = this.rpc.clone(authResponse.signatureOffloaderRPCId);
-        this.signatureOffloader = new SignatureOffloaderRPCClient(rpc1);
+        try {
+            this.pendingAuth = true;
 
-        const rpc2 = this.rpc.clone(authResponse.handshakeRPCId);
-        this.authFactory = new AuthFactoryRPCClient(rpc2);
+            // TODO: pass along this.appConf and take back changes.
+            //
+            const authResponse = await this.rpc.call("auth") as AuthResponse;
 
-        // TODO
-        this.walletConf = ParseUtil.ParseWalletConf({});
+            this.pendingAuth = false;
+
+            if (authResponse.error || !authResponse.signatureOffloaderRPCId || !authResponse.handshakeRPCId) {
+                this._onAuthFail?.(authResponse.error ?? "Unknown error");
+
+                this.close();
+
+                return;
+            }
+
+            const rpc1 = this.rpc.clone(authResponse.signatureOffloaderRPCId);
+            this.signatureOffloader = new SignatureOffloaderRPCClient(rpc1);
+
+            const rpc2 = this.rpc.clone(authResponse.handshakeRPCId);
+            this.authFactory = new AuthFactoryRPCClient(rpc2);
+
+            // TODO
+            this.walletConf = ParseUtil.ParseWalletConf({});
+        }
+        catch(e) {
+            this._onAuthFail?.(`Error in auth process: ${e}`);
+
+            this.close();
+
+            return;
+        }
+
+        try {
+            this.service = new Service(this.appConf, this.walletConf, this.signatureOffloader,
+                this.authFactory);
+
+            await this.service.init();
+        }
+        catch(e) {
+            this._onAuthFail?.(`Could not init Service: ${e}`);
+
+            this.close();
+
+            return;
+        }
+
+        this._onAuth?.(this.service);
     }
 
-    public isPendingAuth(): boolean {
+    public isAuthed = (): boolean => {
+        return this.service !== undefined;
+    }
+
+    public isPendingAuth = (): boolean => {
         return this.pendingAuth;
     }
 
-    public getSignatureOffloader(): SignatureOffloaderInterface | undefined {
+    public getSignatureOffloader = (): SignatureOffloaderInterface | undefined => {
         return this.signatureOffloader;
     }
 
-    public getHandshakeFactoryFactory(): AuthFactoryInterface | undefined {
+    public getHandshakeFactoryFactory = (): AuthFactoryInterface | undefined => {
         return this.authFactory;
     }
 
-    public getWalletConf(): WalletConf | undefined {
+    public getWalletConf = (): WalletConf | undefined => {
         return this.walletConf;
     }
 
-    /**
-     * @throws on error
-     */
-    public async initService(applicationConf: ApplicationConf): Promise<Service> {
-        if (!this.walletConf) {
-            throw new Error("Missing walletConf");
-        }
-
-        if (!this.signatureOffloader) {
-            throw new Error("Missing signatureOffloader");
-        }
-
-        if (!this.authFactory) {
-            throw new Error("Missing authFactory");
-        }
-
-        const service = new Service(applicationConf, this.walletConf, this.signatureOffloader, this.authFactory);
-
-        await service.init()
-
-        return service;
+    public getService = (): Service | undefined => {
+        return this.service;
     }
 
-    public close(): Promise<void> {
+    /**
+     * Close the connection to the datawallet resulting in logout.
+     * The OpenOdin instance cannot be used any further after close.
+     */
+    public close = () => {
+        if (this._isClosed) {
+            return;
+        }
+
+        const rpcId = this.rpc.getId();
+
+        postMessage({message: {rpcId}, direction: "openodin-page-script-close-port"}, "*");
+    }
+
+    public isClosed = () => {
+        return this._isClosed;
+    }
+
+    public isOpen = () => {
+        return this._isOpen;
+    }
+
+    /**
+     * Handle when port is closed or cannot be opened.
+     */
+    protected handleClose() {
+        if (this._isClosed) {
+            return;
+        }
+
+        this._isClosed = true;
+        this.pendingAuth = false;
         delete this.signatureOffloader;
         delete this.authFactory;
 
-        return this.rpc.call("close");
+        this.service?.close();
+
+        delete this.service;
+
+        this._onClose?.();
     }
 
-    public onActive( cb: () => void ) {
-        this._onActive = cb;
+    /**
+     * Event triggered when the Datawallet is opened and activated for the tab.
+     * After this event one can all auth(), if autoAuth is set auth() is called automatically.
+     */
+    public onOpen = ( cb: () => void ) => {
+        this._onOpen = cb;
+    }
+
+    public onPreAuth = ( cb: () => void ) => {
+        // TODO
+    }
+
+    /**
+     * Event triggered on successful authorization.
+     * A newly created and init'd Service instance is passed as argument to the event handler.
+     *
+     * From this point the OpinOdin instance is only useful for calling close() on and/or listening
+     * for the close event, as everything else is now provided in the Service instance.
+     * For handling close events either hook the OpenOdin instance onClose() or the Service onClose().
+     */
+    public onAuth = ( cb: (service: Service) => void ) => {
+        this._onAuth = cb;
+    }
+
+    /**
+     * Event triggered on failed authorization or if port closed during pending authorization.
+     * The OpenOdin instance cannot be reused.
+     */
+    public onAuthFail = ( cb: (error: string) => void ) => {
+        this._onAuthFail = cb;
+    }
+
+    /**
+     * Event triggered when port to background is disconnected or when calling close().
+     *
+     * The OpenOdin instance cannot be used any further after close.
+     */
+    public onClose = ( cb: () => void ) => {
+        this._onClose = cb;
     }
 }

--- a/src/rpc/OpenOdinRPCServer.ts
+++ b/src/rpc/OpenOdinRPCServer.ts
@@ -20,7 +20,6 @@ import {
 } from "./types";
 
 export class OpenOdinRPCServer {
-    protected rpc: RPC;
     protected triggerOnAuth?: (rpcId1: string, rpcId2: string) => Promise<AuthResponse2>;
     protected signatureOffloaderRPCServer?: SignatureOffloaderRPCServer;
     protected authFactoryRPCCserver?: AuthFactoryRPCServer;
@@ -30,10 +29,8 @@ export class OpenOdinRPCServer {
     {
         this.rpc.onCall("auth", this.auth);
 
-        this.rpc.onCall("close", this.close);
-
-        this.rpc.onCall("client-hello", async () => {
-            return "server-hello";
+        this.rpc.onCall("noop", async () => {
+            return "noop";
         });
     }
 
@@ -42,7 +39,8 @@ export class OpenOdinRPCServer {
     }
 
     /**
-     * Close resources created when authed.
+     * Free resources created when authed.
+     * The RPC is not automatically closed.
      */
     public close = () => {
         this.signatureOffloaderRPCServer?.close();

--- a/src/rpc/OpenOdinRPCServer.ts
+++ b/src/rpc/OpenOdinRPCServer.ts
@@ -25,9 +25,9 @@ export class OpenOdinRPCServer {
     protected signatureOffloaderRPCServer?: SignatureOffloaderRPCServer;
     protected authFactoryRPCCserver?: AuthFactoryRPCServer;
 
-    constructor(rpc: RPC) {
-        this.rpc = rpc;
-
+    constructor(protected rpc: RPC, protected nrOfWorkers: number = 1,
+        protected singleThreaded: boolean = false)
+    {
         this.rpc.onCall("auth", this.auth);
 
         this.rpc.onCall("close", this.close);
@@ -82,7 +82,9 @@ export class OpenOdinRPCServer {
             };
         }
 
-        this.signatureOffloaderRPCServer = new SignatureOffloaderRPCServer(rpc1, 1);  // Only use one separate worker thread in RPC (browser) scenarios.
+        this.signatureOffloaderRPCServer = new SignatureOffloaderRPCServer(rpc1, this.nrOfWorkers,
+            this.singleThreaded);
+
         await this.signatureOffloaderRPCServer.init();
 
         const keyPairs2: KeyPair[] = [];

--- a/src/rpc/SignatureOffloaderRPCServer.ts
+++ b/src/rpc/SignatureOffloaderRPCServer.ts
@@ -74,4 +74,10 @@ export class SignatureOffloaderRPCServer extends SignatureOffloader {
             return this.verifier(signaturesCollections);
         });
     }
+
+    public async close() {
+        this.rpc.close();
+
+        return super.close();
+    }
 }

--- a/src/rpc/SignatureOffloaderRPCServer.ts
+++ b/src/rpc/SignatureOffloaderRPCServer.ts
@@ -19,8 +19,8 @@ import {
 export class SignatureOffloaderRPCServer extends SignatureOffloader {
     protected rpc: RPC;
 
-    constructor(rpc: RPC, workers?: number) {
-        super(workers);
+    constructor(rpc: RPC, nrOfWorkers?: number, singleThreaded: boolean = false) {
+        super(nrOfWorkers, singleThreaded);
 
         this.rpc = rpc;
 

--- a/src/rpc/SocketRPCServer.ts
+++ b/src/rpc/SocketRPCServer.ts
@@ -80,6 +80,12 @@ export class SocketRPCServer {
         });
     }
 
+    public close() {
+        this.rpc.close();
+
+        this.client.close();
+    }
+
     protected socketData = (data: Buffer | string) => {
         this.rpc.call(this.rpcPrefix + "onData", [data]);
     }

--- a/src/service/Service.ts
+++ b/src/service/Service.ts
@@ -1094,7 +1094,7 @@ export class Service {
                     blobDriver?.close();
                 });
 
-                storage.init();
+                await storage.init();
 
                 // This client only initiates requests and does not need any permissions to it.
                 const internalStorageClient = new P2PClient(messaging2, localPeerData,

--- a/src/service/Service.ts
+++ b/src/service/Service.ts
@@ -742,7 +742,7 @@ export class Service {
     }
 
     /**
-     * This is a suger function over addAutoFetch which uses a Thread template.
+     * This is a sugar function over addAutoFetch which uses a Thread template.
      */
     public addSync(sync: SyncConf) {
         this.syncConfToAutoFetch(sync).forEach( autoFetch => this.addAutoFetch(autoFetch) );

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -88,6 +88,9 @@ export type StorageConf = {
     database?:  DatabaseConfig,
 };
 
+/**
+ * Configuration for automatically instantiating Threads for synchronization.
+ */
 export type SyncConf = {
     peerPublicKeys:    Buffer[],
 
@@ -115,34 +118,6 @@ export type SyncConf = {
 
         threadFetchParams: ThreadFetchParams,
     }[],
-};
-
-/**
- * This is an alternative approach of adding auto sync
- * using an instantiated thread as template.
- */
-export type ThreadSyncConf = {
-    /**
-     * @default true
-     */
-    stream?: boolean,
-
-    /**
-     * @default "both"
-     */
-    direction?: "pull" | "push" | "both",  // defaults to "both"
-
-    /**
-     * @default -1
-     */
-    blobSizeMaxLimit?:  number,
-
-    /**
-     * @default
-     * [Buffer.alloc(0)]
-     * which means match every remote public key.
-     */
-    peerPublicKeys?:    Buffer[],
 };
 
 export type ApplicationConf = {

--- a/src/signatureoffloader/NonThreadedWorker.ts
+++ b/src/signatureoffloader/NonThreadedWorker.ts
@@ -1,0 +1,89 @@
+import {
+    RPC,
+} from "../util/RPC";
+
+import {
+    SignatureOffloaderWorker,
+} from "./SignatureOffloaderWorker";
+
+import {
+    KeyPair,
+} from "../datamodel/types";
+
+import {
+    ToBeSigned,
+    SignaturesCollection,
+} from "./types";
+
+export class NonThreadedWorker {
+    protected cb?: Function;
+
+    protected listener?: Function;
+
+    // Faking the Worker interface
+    //
+    public onerror: any;
+
+    constructor(_?: string) {
+        const postMessage = (event: any) => {
+            this.cb?.(event);
+        };
+
+        const addEventListener = (_: "message", listener: Function) => {
+            this.listener = listener;
+        };
+
+        main(postMessage, addEventListener);
+    }
+
+    public postMessage(message: any) {
+        this.listener?.(message);
+    }
+
+    public addEventListener(topic: "message", cb: Function) {
+        this.cb = cb;
+    }
+
+    public terminate() {
+    }
+}
+
+function main(postMessage: Function, addEventListener: Function) {
+    const postMessageWrapped = (message: any) => {
+        const event = {
+            type: "message",
+            timeStamp: Date.now(),
+            data: {
+                message,
+            },
+            currentTarget: undefined,
+            target: undefined,
+        };
+
+        postMessage(event);
+    };
+
+    const listenMessage = (listener: any) => {
+        addEventListener("message", (data: any) => {
+            listener(data.message);
+        });
+    };
+
+    const signatureOffloaderWorker = new SignatureOffloaderWorker();
+
+    const rpc = new RPC(postMessageWrapped, listenMessage);
+
+    rpc.onCall("addKeyPair", (keyPair: KeyPair) => {
+        return signatureOffloaderWorker.addKeyPair(keyPair);
+    });
+
+    rpc.onCall("verify", (signaturesCollections: SignaturesCollection[]) => {
+        return signatureOffloaderWorker.verify(signaturesCollections);
+    });
+
+    rpc.onCall("sign", (toBeSigned: ToBeSigned[]) => {
+        return signatureOffloaderWorker.sign(toBeSigned);
+    });
+
+    signatureOffloaderWorker.init().then( () => rpc.call("hello") );
+}

--- a/src/signatureoffloader/SignatureOffloaderWorker.ts
+++ b/src/signatureoffloader/SignatureOffloaderWorker.ts
@@ -1,0 +1,181 @@
+import {
+    KeyPair,
+} from "../datamodel/types";
+
+import {
+    Crypto,
+} from "../datamodel/Crypto";
+
+import {
+    ToBeSigned,
+    SignaturesCollection,
+    SignedResult,
+} from "./types";
+
+const sodium = require("libsodium-wrappers");  //eslint-disable-line @typescript-eslint/no-var-requires
+
+export class SignatureOffloaderWorker {
+    protected keyPairs: KeyPair[] = [];
+
+    public async init() {
+        await sodium.ready;
+    }
+
+    public addKeyPair(keyPair: KeyPair) {
+        this.keyPairs.push({
+            publicKey: Buffer.from(keyPair.publicKey),
+            secretKey: Buffer.from(keyPair.secretKey),
+        });
+
+        return;
+    }
+
+    public verify(signaturesCollections: SignaturesCollection[]): number[]  {
+        const result: number[] = [];
+
+        const l = signaturesCollections.length;
+        for (let i=0; i<l; i++) {
+
+            const {index, signatures} = signaturesCollections[i];
+
+            let validCount = 0;
+
+            const l2 = signatures.length;
+
+            for (let j=0; j<l2; j++) {
+
+                const {message, signature, publicKey} = signatures[j];
+
+                // These can be Uint8Arrays after serialization so we make sure they are Buffers.
+                //
+                const message2   = Buffer.from(message);
+                const signature2 = Buffer.from(signature);
+                const publicKey2 = Buffer.from(publicKey);
+
+                if (Crypto.IsEd25519(publicKey2)) {
+                    // Use sodium to verify signature in high speed.
+                    //
+                    try {
+                        if (sodium.crypto_sign_verify_detached(signature2, message2,
+                            publicKey2))
+                        {
+                            validCount++;
+                            continue;
+                        }
+                        else {
+                            // Could not verify signature,
+                            // do not attempt to verify any further.
+                            //
+                            break;
+                        }
+                    }
+                    catch(e) {
+                        // Could not verify signature,
+                        // do not attempt to verify any further.
+                        //
+                        break;
+                    }
+                }
+                else {
+                    // Resolve other cases which are not ed25519
+                    //
+                    try {
+                        if (Crypto.Verify({message: message2, signature: signature2,
+                                publicKey: publicKey2, index}))
+                        {
+                            validCount++
+                            continue;
+                        }
+                    }
+                    catch(e) {
+                        // Fall through
+                    }
+
+                    // Could not verify signature,
+                    // do not attempt to verify any further.
+                    //
+                    break;
+                }
+            }
+
+            if (validCount === l2) {
+                // All signatures in the collection verified.
+                //
+                result.push(index);
+            }
+        }
+
+        return result;
+    }
+
+    public sign(toBeSigned: ToBeSigned[]): SignedResult[] {
+        const result: SignedResult[] = [];
+
+        const l = toBeSigned.length;
+
+        for (let j=0; j<l; j++) {
+            const {index, message, publicKey} = toBeSigned[j];
+
+            // These are serialized as Uint8Array so we want it back as Buffer to be able to use equals().
+            //
+            const publicKey2 = Buffer.from(publicKey);
+            const message2   = Buffer.from(message);
+
+            const keyPairsLength = this.keyPairs.length;
+
+            // Find the matching secretKey so we can sign.
+            //
+            let secretKey: Buffer | undefined;
+
+            for (let i=0; i<keyPairsLength; i++) {
+
+                const keyPair = this.keyPairs[i];
+
+                if (keyPair.publicKey.equals(publicKey2)) {
+                    secretKey = keyPair.secretKey;
+                    break;
+                }
+            }
+
+            if (!secretKey) {
+                continue;
+            }
+
+            if (Crypto.IsEd25519(publicKey)) {
+                try {
+                    // Use sodium to sign in high speed.
+                    //
+                    const signature = Buffer.from(sodium.crypto_sign_detached(message2, secretKey));
+
+                    result.push({index, signature});
+                }
+                catch(e) {
+                    // Abort
+                    //
+                    return [];
+                }
+            }
+            else {
+                try {
+                    // Resolve other cases which are not ed25519
+                    //
+                    const keyPair = {
+                        publicKey,
+                        secretKey,
+                    };
+
+                    const signature = Crypto.Sign(message2, keyPair);
+
+                    result.push({index, signature});
+                }
+                catch(e) {
+                    // Abort
+                    //
+                    return [];
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/signatureoffloader/SignatureOffloaderWorker.ts
+++ b/src/signatureoffloader/SignatureOffloaderWorker.ts
@@ -33,16 +33,16 @@ export class SignatureOffloaderWorker {
     public verify(signaturesCollections: SignaturesCollection[]): number[]  {
         const result: number[] = [];
 
-        const l = signaturesCollections.length;
-        for (let i=0; i<l; i++) {
+        const len = signaturesCollections.length;
+        for (let i=0; i<len; i++) {
 
             const {index, signatures} = signaturesCollections[i];
 
             let validCount = 0;
 
-            const l2 = signatures.length;
+            const len2 = signatures.length;
 
-            for (let j=0; j<l2; j++) {
+            for (let j=0; j<len2; j++) {
 
                 const {message, signature, publicKey} = signatures[j];
 
@@ -98,7 +98,7 @@ export class SignatureOffloaderWorker {
                 }
             }
 
-            if (validCount === l2) {
+            if (validCount === len2) {
                 // All signatures in the collection verified.
                 //
                 result.push(index);

--- a/src/signatureoffloader/index.ts
+++ b/src/signatureoffloader/index.ts
@@ -1,2 +1,3 @@
 export * from "./SignatureOffloader";
+export * from "./SignatureOffloaderWorker";
 export * from "./types";

--- a/src/signatureoffloader/signatureOffloader-worker.ts
+++ b/src/signatureoffloader/signatureOffloader-worker.ts
@@ -15,182 +15,17 @@ import {
 } from "../util/RPC";
 
 import {
+    ToBeSigned,
+    SignaturesCollection,
+} from "./types";
+
+import {
     KeyPair,
 } from "../datamodel/types";
 
 import {
-    Crypto,
-} from "../datamodel/Crypto";
-
-import {
-    ToBeSigned,
-    SignaturesCollection,
-    SignedResult,
-} from "./types";
-
-const sodium = require("libsodium-wrappers");  //eslint-disable-line @typescript-eslint/no-var-requires
-
-export class SignatureOffloaderWorker {
-    protected keyPairs: KeyPair[] = [];
-
-    public addKeyPair(keyPair: KeyPair) {
-        this.keyPairs.push({
-            publicKey: Buffer.from(keyPair.publicKey),
-            secretKey: Buffer.from(keyPair.secretKey),
-        });
-
-        return;
-    }
-
-    public verify(signaturesCollections: SignaturesCollection[]): number[]  {
-        const result: number[] = [];
-
-        const l = signaturesCollections.length;
-        for (let i=0; i<l; i++) {
-
-            const {index, signatures} = signaturesCollections[i];
-
-            let validCount = 0;
-
-            const l2 = signatures.length;
-
-            for (let j=0; j<l2; j++) {
-
-                const {message, signature, publicKey} = signatures[j];
-
-                // These can be Uint8Arrays after serialization so we make sure they are Buffers.
-                //
-                const message2   = Buffer.from(message);
-                const signature2 = Buffer.from(signature);
-                const publicKey2 = Buffer.from(publicKey);
-
-                if (Crypto.IsEd25519(publicKey2)) {
-                    // Use sodium to verify signature in high speed.
-                    //
-                    try {
-                        if (sodium.crypto_sign_verify_detached(signature2, message2,
-                            publicKey2))
-                        {
-                            validCount++;
-                            continue;
-                        }
-                        else {
-                            // Could not verify signature,
-                            // do not attempt to verify any further.
-                            //
-                            break;
-                        }
-                    }
-                    catch(e) {
-                        // Could not verify signature,
-                        // do not attempt to verify any further.
-                        //
-                        break;
-                    }
-                }
-                else {
-                    // Resolve other cases which are not ed25519
-                    //
-                    try {
-                        if (Crypto.Verify({message: message2, signature: signature2,
-                                publicKey: publicKey2, index}))
-                        {
-                            validCount++
-                            continue;
-                        }
-                    }
-                    catch(e) {
-                        // Fall through
-                    }
-
-                    // Could not verify signature,
-                    // do not attempt to verify any further.
-                    //
-                    break;
-                }
-            }
-
-            if (validCount === l2) {
-                // All signatures in the collection verified.
-                //
-                result.push(index);
-            }
-        }
-
-        return result;
-    }
-
-    public sign(toBeSigned: ToBeSigned[]): SignedResult[] {
-        const result: SignedResult[] = [];
-
-        const l = toBeSigned.length;
-
-        for (let j=0; j<l; j++) {
-            const {index, message, publicKey} = toBeSigned[j];
-
-            // These are serialized as Uint8Array so we want it back as Buffer to be able to use equals().
-            //
-            const publicKey2 = Buffer.from(publicKey);
-            const message2   = Buffer.from(message);
-
-            const keyPairsLength = this.keyPairs.length;
-
-            // Find the matching secretKey so we can sign.
-            //
-            let secretKey: Buffer | undefined;
-
-            for (let i=0; i<keyPairsLength; i++) {
-
-                const keyPair = this.keyPairs[i];
-
-                if (keyPair.publicKey.equals(publicKey2)) {
-                    secretKey = keyPair.secretKey;
-                    break;
-                }
-            }
-
-            if (!secretKey) {
-                continue;
-            }
-
-            if (Crypto.IsEd25519(publicKey)) {
-                try {
-                    // Use sodium to sign in high speed.
-                    //
-                    const signature = Buffer.from(sodium.crypto_sign_detached(message2, secretKey));
-
-                    result.push({index, signature});
-                }
-                catch(e) {
-                    // Abort
-                    //
-                    return [];
-                }
-            }
-            else {
-                try {
-                    // Resolve other cases which are not ed25519
-                    //
-                    const keyPair = {
-                        publicKey,
-                        secretKey,
-                    };
-
-                    const signature = Crypto.Sign(message2, keyPair);
-
-                    result.push({index, signature});
-                }
-                catch(e) {
-                    // Abort
-                    //
-                    return [];
-                }
-            }
-        }
-
-        return result;
-    }
-}
+    SignatureOffloaderWorker,
+} from "./SignatureOffloaderWorker";
 
 function main(self?: any) {
     // In case of Browser, self is likely to be set.
@@ -225,9 +60,7 @@ function main(self?: any) {
         return signatureOffloaderWorker.sign(toBeSigned);
     });
 
-    sodium.ready.then( () => {
-        rpc.call("hello");
-    });
+    signatureOffloaderWorker.init().then( () => rpc.call("hello") );
 }
 
 main();

--- a/src/storage/QueryProcessor.ts
+++ b/src/storage/QueryProcessor.ts
@@ -320,7 +320,7 @@ export class QueryProcessor {
                         await this.db.each(sql, params, this.addRow);
                     }
                     catch(e) {
-                        console.debug("error in db.each", e);
+                        console.error("error in db.each", e);
                         this._error = e as Error;
                         break;
                     }
@@ -399,7 +399,7 @@ export class QueryProcessor {
             }
         }
         catch(e) {
-            console.debug("Exception in QueryProcessor.addRow", e);
+            console.error("Exception in QueryProcessor.addRow", e);
             // Do nothing
         }
 
@@ -1036,7 +1036,7 @@ export class QueryProcessor {
                 }
             }
             catch(e) {
-                console.debug(e);
+                console.error(e);
                 continue;
             }
 
@@ -1457,7 +1457,7 @@ export class QueryProcessor {
                 }
             }
             catch(e) {
-                console.debug(e);
+                console.error(e);
                 return {};
             }
         }
@@ -1711,7 +1711,7 @@ export class QueryProcessor {
                             }
                         }
                         catch (e) {
-                            console.debug(e);
+                            console.error(e);
                             eyesOnNode = undefined;
                         }
                     }
@@ -1864,7 +1864,7 @@ export class QueryProcessor {
                             }
                         }
                         catch (e) {
-                            console.debug(e);
+                            console.error(e);
                             eyesOnNode = undefined;
                         }
                     }
@@ -1885,7 +1885,11 @@ export class QueryProcessor {
 
         const licenseNodeId1s = Object.values(addedLicenses);
 
-        const licenseNodes = await this.getNodesById1(licenseNodeId1s) as LicenseInterface[];
+        const licenseNodes: LicenseInterface[] = [];
+
+        while (licenseNodeId1s.length > 0) {
+            licenseNodes.push(...await this.getNodesById1(licenseNodeId1s.splice(0, MAX_BATCH_SIZE)) as LicenseInterface[]);
+        }
 
         return [allowedNodes, licenseNodes];
     }
@@ -2157,7 +2161,7 @@ export class QueryProcessor {
                 }
             }
             catch(e) {
-                console.debug(e);
+                console.error(e);
                 return {};
             }
         }
@@ -2272,7 +2276,7 @@ export class QueryProcessor {
             }
         }
         catch(e) {
-            console.debug("Exception calling node.checkFilters", e);
+            console.error("Exception calling node.checkFilters", e);
         }
 
         return false;
@@ -2315,7 +2319,7 @@ export class QueryProcessor {
                 nodes.push(node);
             }
             catch(e) {
-                console.debug(e);
+                console.error(e);
             }
         }
 

--- a/src/storage/QueryProcessor.ts
+++ b/src/storage/QueryProcessor.ts
@@ -320,7 +320,7 @@ export class QueryProcessor {
                         await this.db.each(sql, params, this.addRow);
                     }
                     catch(e) {
-                        console.error("error in db.each", e);
+                        console.debug("error in db.each", e);
                         this._error = e as Error;
                         break;
                     }

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -180,7 +180,7 @@ export class Storage {
      * Always call this after instantiating the Storage.
      * It will hook the p2p events.
      */
-    public init() {
+    public async init() {
         this.driver.onClose( () => this.close());
         this.blobDriver?.onClose( () => this.close());
         this.p2pClient.onStore( this.handleStore );
@@ -189,6 +189,8 @@ export class Storage {
         this.p2pClient.onReadBlob( this.handleReadBlob );
         this.p2pClient.onWriteBlob( this.handleWriteBlob );
         this.p2pClient.onClose( this.handleClose );
+
+        await this.crdtManager.init();
     }
 
     /**

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -639,14 +639,6 @@ export class Storage {
         try {
             const now = this.timeFreeze.read();
 
-            const mutex1 = this.lock.acquire("driver");
-
-            locks.push(mutex1);
-
-            if (mutex1.p) {
-                await mutex1.p;
-            }
-
             const usesCrdt = fetchRequest.crdt.algo > 0;
 
             if (usesCrdt) {
@@ -666,10 +658,19 @@ export class Storage {
                 this.lock.release(mutex2);
             }
             else {
+                const mutex1 = this.lock.acquire("driver");
+
+                locks.push(mutex1);
+
+                if (mutex1.p) {
+                    await mutex1.p;
+                }
+
                 await this.driver.fetch(fetchRequest.query, now, handleFetchReplyData);
+
+                this.lock.release(mutex1);
             }
 
-            this.lock.release(mutex1);
 
             if (trigger?.closed) {
                 this.dropTrigger(trigger.msgId, trigger.fetchRequest.query.targetPublicKey);
@@ -1431,114 +1432,107 @@ export class Storage {
 
         let rowCount: number = 0
 
-        // The fetch drives through here.
-        const fn = async (fetchReplyData: FetchReplyData) => {
-            const mutex1 = this.lock.acquire(`fetch_${key}`);
+        const allNodesToAdd: DataInterface[] = [];
 
-            if (mutex1.p) {
-                await mutex1.p;
+        // The fetch drives through here.
+        //
+        const aggregateFn = (fetchReplyData: FetchReplyData) => {
+            const status = fetchReplyData.status ?? Status.RESULT;
+
+            if (status !== Status.RESULT) {
+                handleFetchReplyData(fetchReplyData);
+                return;
             }
 
-            try {
-                const status = fetchReplyData.status ?? Status.RESULT;
+            // For CRDT models we only include data nodes,
+            // which are not flagged as special nodes.
+            //
+            const nodesToAdd = (fetchReplyData.nodes ?? []).
+                filter( node => node.getType().equals(DATA_NODE_TYPE) &&
+                    !(node as DataInterface).isSpecial() ) as DataInterface[];
 
-                if (status !== Status.RESULT) {
-                    handleFetchReplyData(fetchReplyData);
-                    return;
+            const embed = fetchReplyData.embed ?? [];
+
+            rowCount += fetchReplyData.rowCount ?? 0;
+
+            allNodesToAdd.push(...nodesToAdd);
+
+            if (embed.length > 0) {
+                const fetchReplyData: FetchReplyData = {
+                    nodes: [],
+                    embed,
+                    rowCount,
+                    isLast: false,
+                };
+
+                handleFetchReplyData(fetchReplyData);
+            }
+        };
+
+        const diffFn = async () => {
+            const currentCRDTView = trigger?.crdtView ??
+                {list: [], transientHashes: {}, annotations: {}};
+
+            const result = await this.crdtManager.diff(currentCRDTView, key,
+                fetchRequest.crdt.cursorId1,
+                fetchRequest.crdt.cursorIndex,
+                fetchRequest.crdt.head,
+                fetchRequest.crdt.tail,
+                fetchRequest.crdt.reverse);
+
+
+            if (!result) {
+                const fetchReplyData: FetchReplyData = {
+                    status: Status.MISSING_CURSOR,
+                    rowCount,
+                    isLast: true,
+                };
+
+                handleFetchReplyData(fetchReplyData);
+            }
+            else {
+                const [missingNodesId1s, delta, crdtView, cursorIndex, length] = result;
+
+                if (trigger) {
+                    trigger.crdtView = crdtView;
                 }
 
-                // For CRDT models we only include data nodes,
-                // which are not flagged as special nodes.
-                const nodesToAdd = (fetchReplyData.nodes ?? []).
-                    filter( node => node.getType().equals(DATA_NODE_TYPE) && !(node as DataInterface).isSpecial() ) as DataInterface[];
+                let isLast = false;
 
-                const embed = fetchReplyData.embed ?? [];
+                while (!isLast) {
+                    const id1s = missingNodesId1s.splice(0, MAX_BATCH_SIZE);
 
-                rowCount += fetchReplyData.rowCount ?? 0;
+                    const nodes = await this.driver.getNodesById1(id1s, now);
 
-                await this.crdtManager.updateModel(fetchRequest, nodesToAdd);
+                    nodes.forEach( node => {
+                        const id1Str = node.getId1()!.toString("hex");
 
-                if (embed.length > 0) {
+                        const annotations = crdtView.annotations[id1Str];
+
+                        if (annotations) {
+                            try {
+                                (node as DataInterface).setAnnotations(annotations);
+                            }
+                            catch(e) {
+                                // Ignore error, could be a too large annotation.
+                                console.error("Could not set annotations on node", e);
+                            }
+                        }
+                    });
+
+                    isLast = missingNodesId1s.length === 0;
+
                     const fetchReplyData: FetchReplyData = {
-                        nodes: [],
-                        embed,
+                        nodes,
+                        delta: isLast ? delta : undefined,
                         rowCount,
-                        isLast: false,
+                        cursorIndex,
+                        length,
+                        isLast,
                     };
 
                     handleFetchReplyData(fetchReplyData);
                 }
-
-                if (fetchReplyData.isLast) {
-                    const currentCRDTView = trigger?.crdtView ??
-                        {list: [], transientHashes: {}, annotations: {}};
-
-                    const result = await this.crdtManager.diff(currentCRDTView, key,
-                        fetchRequest.crdt.cursorId1,
-                        fetchRequest.crdt.cursorIndex,
-                        fetchRequest.crdt.head,
-                        fetchRequest.crdt.tail,
-                        fetchRequest.crdt.reverse);
-
-                    if (!result) {
-                        const fetchReplyData: FetchReplyData = {
-                            status: Status.MISSING_CURSOR,
-                            rowCount,
-                            isLast: true,
-                        };
-
-                        handleFetchReplyData(fetchReplyData);
-                    }
-                    else {
-                        const [missingNodesId1s, delta, crdtView, cursorIndex, length] = result;
-
-                        if (trigger) {
-                            trigger.crdtView = crdtView;
-                        }
-
-                        while (true) {
-                            const id1s = missingNodesId1s.splice(0, MAX_BATCH_SIZE);
-
-                            const nodes = await this.driver.getNodesById1(id1s, now);
-
-                            nodes.forEach( node => {
-                                const id1Str = node.getId1()!.toString("hex");
-
-                                const annotations = crdtView.annotations[id1Str];
-
-                                if (annotations) {
-                                    try {
-                                        (node as DataInterface).setAnnotations(annotations);
-                                    }
-                                    catch(e) {
-                                        // Ignore error, could be a too large annotation.
-                                        console.error("Could not set annotations on node", e);
-                                    }
-                                }
-                            });
-
-                            const isLast = missingNodesId1s.length === 0;
-
-                            const fetchReplyData: FetchReplyData = {
-                                nodes,
-                                delta: isLast ? delta : undefined,
-                                rowCount,
-                                cursorIndex,
-                                length,
-                                isLast,
-                            };
-
-                            handleFetchReplyData(fetchReplyData);
-
-                            if (missingNodesId1s.length === 0) {
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-            finally {
-                this.lock.release(mutex1);
             }
         };
 
@@ -1548,11 +1542,32 @@ export class Storage {
             await this.crdtManager.beginDeletionTracking(key);
         }
 
-        // Drive the fetch through the CRDT model.
-        await this.driver.fetch(fetchRequest.query, now, fn);
+        const mutex1 = this.lock.acquire("driver");
 
-        if (detectDeletions) {
-            await this.crdtManager.commitDeletionTracking(key);
+        if (mutex1.p) {
+            await mutex1.p;
+        }
+
+        const t1 = Date.now();
+
+        // Drive the fetch through the CRDT model.
+        //
+        try {
+            await this.driver.fetch(fetchRequest.query, now, aggregateFn);
+        }
+        finally {
+            this.lock.release(mutex1);
+        }
+
+        try {
+            this.crdtManager.updateModel(fetchRequest, allNodesToAdd);
+
+            await diffFn();
+        }
+        finally {
+            if (detectDeletions) {
+                await this.crdtManager.commitDeletionTracking(key);
+            }
         }
     }
 }

--- a/src/storage/crdt/CRDTManager.ts
+++ b/src/storage/crdt/CRDTManager.ts
@@ -24,17 +24,21 @@ import * as fossilDelta from "fossil-delta";
 
 import Worker from "web-worker";
 
-// Check current environment: Node.js or Browser ?
+// Check current environment: Node.js, browser or browser plugin.
+//
 declare const window: any;
+declare const process: any;
+declare const browser: any;
+declare const chrome: any;
 
 import { strict as assert } from "assert";
 
 const isNode = (typeof process !== "undefined" && process?.versions?.node);
 let isBrowser = false;
 if (!isNode) {
-    isBrowser = (typeof window !== "undefined");
+    isBrowser = typeof window !== "undefined" || typeof browser !== "undefined" || typeof chrome !== "undefined";
     if(!isBrowser) {
-        assert(false, "Unexpected error: current environment is neither Node.js or Browser");
+        assert(false, "Unexpected error: current environment is neither Node.js, browser or browser extension");
     }
 }
 
@@ -97,7 +101,7 @@ export class CRDTManager {
 
             const listenMessage = (listener: any) => {
                 this.workerThread?.addEventListener("message", (event: any) => {
-                    listener(event.data.message);
+                    listener(event.data?.message);
                 });
             };
 

--- a/src/storage/crdt/CRDTManager.ts
+++ b/src/storage/crdt/CRDTManager.ts
@@ -159,7 +159,7 @@ export class CRDTManager {
 
         const images: Buffer[] = nodes.map( node => node.export(true) );
 
-        await this.rpc?.call("updateModel", [key, algoId, conf, fetchRequest.query.orderByStorageTime,
+        return this.rpc?.call("updateModel", [key, algoId, conf, fetchRequest.query.orderByStorageTime,
             images, fetchRequest.query.targetPublicKey]);
     }
 

--- a/src/storage/crdt/CRDTView.ts
+++ b/src/storage/crdt/CRDTView.ts
@@ -11,12 +11,10 @@ import {
     CRDTViewModel,
     CRDTViewItem,
     CRDTViewExternalData,
-    CRDTVIEW_EVENT,
+    CRDTOnChangeCallback,
 } from "./types";
 
 import * as fossilDelta from "fossil-delta";
-
-type ONCHANGE_CALLBACK = (crdtViewEvents: CRDTVIEW_EVENT) => void;
 
 export class CRDTView {
     protected handlers: {[name: string]: ( (...args: any) => void)[]} = {};
@@ -134,14 +132,8 @@ export class CRDTView {
         return datas;
     }
 
-    public triggerOnChange(added: Buffer[], updated: Buffer[], deleted: Buffer[]) {
-        const crdtViewEvent: CRDTVIEW_EVENT = {
-            added,
-            deleted,
-            updated,
-        };
-
-        this.triggerEvent("change", crdtViewEvent);
+    public triggerOnChange(addedId1s: Buffer[], updatedId1s: Buffer[], deletedId1s: Buffer[]) {
+        this.triggerEvent("change", addedId1s, updatedId1s, deletedId1s);
     }
 
     /**
@@ -249,7 +241,7 @@ export class CRDTView {
         this.handleResponse([], Buffer.alloc(0));
     }
 
-    public onChange(cb: ONCHANGE_CALLBACK): CRDTView {
+    public onChange(cb: CRDTOnChangeCallback): CRDTView {
         this.hookEvent("change", cb);
 
         return this;

--- a/src/storage/crdt/types.ts
+++ b/src/storage/crdt/types.ts
@@ -83,7 +83,9 @@ export function ExtractNodeValuesRefId(node: DataInterface): NodeValuesRefId {
 export type CRDTViewExternalData = {[key: string]: any};
 
 export type CRDTViewItem = {
+    /** The index of the node in the model. */
     index: number,
+
     id1: Buffer,
     node: DataInterface,
     data: CRDTViewExternalData,
@@ -104,13 +106,4 @@ export type CRDTViewModel = {
     datas: {[id1: string]: CRDTViewExternalData},
 };
 
-export type CRDTVIEW_EVENT = {
-    /** List of node ID1s which have been added to the model. */
-    added: Buffer[],
-
-    /** List of node ID1s of existing nodes who's transient values have been updated. */
-    updated: Buffer[],
-
-    /** List of node ID1s of nodes who have deen deleted from the model. */
-    deleted: Buffer[],
-};
+export type CRDTOnChangeCallback = (addedId1s: Buffer[], updatedId1s: Buffer[], deletedId1s: Buffer[]) => void;

--- a/src/storage/thread/Thread.ts
+++ b/src/storage/thread/Thread.ts
@@ -739,13 +739,13 @@ export class Thread {
             const storeResponse = anyData.response;
 
             if (!storeResponse || storeResponse.status !== Status.RESULT) {
-                throw new Error(`Could not store nodes: ${storeResponse?.error}`);
+                throw new Error(`Could not store nodes, status=${storeResponse?.status} error=${storeResponse?.error}`);
             }
 
             return storeResponse.storedId1s;
         }
         else {
-            throw new Error(`Could not store nodes: ${anyData.error}`);
+            throw new Error(`Could not store nodes, type=${anyData.type}, error=${anyData.error}`);
         }
     }
 

--- a/src/storage/thread/Thread.ts
+++ b/src/storage/thread/Thread.ts
@@ -616,7 +616,7 @@ export class Thread {
         }
 
         if (expireTime === undefined) {
-            expireTime = Date.now() + 30 * 24 * 3600;
+            expireTime = Date.now() + 30 * 24 * 3600 * 1000;
         }
 
         const nodeExpireTime = node.getExpireTime();

--- a/src/storage/thread/Thread.ts
+++ b/src/storage/thread/Thread.ts
@@ -371,6 +371,7 @@ export class Thread {
         crdtView: CRDTView | undefined,
         fetchRequest: FetchRequest): ThreadStreamResponseAPI
     {
+        fetchRequest = DeepCopy(fetchRequest);
 
         const onDataCBs: Array<(nodes: DataInterface[]) => void> = [];
 
@@ -456,7 +457,6 @@ export class Thread {
 
             updateStream: (updateStreamParams: UpdateStreamParams) => {
                 // Replace with our new
-                fetchRequest = DeepCopy(fetchRequest);
 
                 fetchRequest.crdt.msgId = getResponse.getMsgId();
 
@@ -497,6 +497,10 @@ export class Thread {
                 }
 
                 return crdtView;
+            },
+
+            getFetchRequest(): FetchRequest {
+                return DeepCopy(fetchRequest);
             },
         };
 

--- a/src/storage/thread/Thread.ts
+++ b/src/storage/thread/Thread.ts
@@ -391,7 +391,6 @@ export class Thread {
             }
             else if (fetchResponse.status !== Status.RESULT) {
                 console.debug(`Error code (${fetchResponse.status}) returned on fetch, error message: ${fetchResponse.error}`);
-
             }
             else {
                 const nodes = (StorageUtil.ExtractFetchResponseNodes(fetchResponse, fetchRequest.query.preserveTransient,
@@ -415,7 +414,11 @@ export class Thread {
                     if (isLast) {
                         delta = Buffer.alloc(0);
 
-                        crdtView.triggerOnChange(addedNodesId1s, updatedNodesId1s, deletedNodesId1s);
+                        if (addedNodesId1s.length > 0 || updatedNodesId1s.length > 0 ||
+                            deletedNodesId1s.length > 0)
+                        {
+                            crdtView.triggerOnChange(addedNodesId1s, updatedNodesId1s, deletedNodesId1s);
+                        }
 
                         addedNodesId1s = [];
                         updatedNodesId1s = [];

--- a/src/storage/thread/ThreadController.ts
+++ b/src/storage/thread/ThreadController.ts
@@ -195,8 +195,40 @@ export class ThreadController {
         return this.service.getPublicKey();
     }
 
+    /**
+     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.tail
+     *
+     * @returns the current (possibly updated) value of tail.
+     */
     public getTail(): number {
-        return this.thread.getFetchRequest(this.params.threadFetchParams).crdt.tail;
+        return this.threadStreamResponseAPI.getFetchRequest().crdt.tail;
+    }
+
+    /**
+     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.head
+     *
+     * @returns the current (possibly updated) value of head.
+     */
+    public getHead(): number {
+        return this.threadStreamResponseAPI.getFetchRequest().crdt.head;
+    }
+
+    /**
+     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.cursorId1
+     *
+     * @returns the current (possibly updated) value of cursorId1.
+     */
+    public getCursorId1(): Buffer {
+        return this.threadStreamResponseAPI.getFetchRequest().crdt.cursorId1;
+    }
+
+    /**
+     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.cursorIndex
+     *
+     * @returns the current (possibly updated) value of cursorIndex.
+     */
+    public getCursorIndex(): number {
+        return this.threadStreamResponseAPI.getFetchRequest().crdt.cursorIndex;
     }
 
     /**

--- a/src/storage/thread/ThreadController.ts
+++ b/src/storage/thread/ThreadController.ts
@@ -1,10 +1,13 @@
 /**
  * ThreadControllers work on Threads who are using CRDTs.
- * They provide a model to be used by the UI, either the CRDT view model (with added data) or its own model.
+ *
+ * They provide a model to be used by the UI, either the CRDT view model (with added data)
+ * or its own model.
  *
  * A ThreadController always runs a streaming fetch request using a CRDT.
  *
- * The underlaying FetchRequest can be updated to allow for expanding/changing the scope of the model (for example for paging and expanding history).
+ * The underlaying FetchRequest can be updated to allow for expanding/changing the scope of the
+ * model (for example for paging and expanding history).
  */
 
 import {
@@ -12,11 +15,15 @@ import {
 } from "./Thread";
 
 import {
-    ThreadDefaults,
     ThreadFetchParams,
+    ThreadTemplate,
     ThreadStreamResponseAPI,
     UpdateStreamParams,
 } from "./types";
+
+import {
+    FetchRequest,
+} from "../../types";
 
 import {
     DataInterface,
@@ -25,61 +32,145 @@ import {
 import {
     CRDTViewExternalData,
     CRDTViewItem,
-    CRDTVIEW_EVENT,
 } from "../crdt/types";
 
 import {
     Service,
 } from "../../service/Service";
 
-export type ThreadControllerParams = {
-    threadName?: string,  // this is optional just so extending classes can set the default.
+import {
+    AutoFetch,
+} from "../../p2pclient/types";
 
-    threadDefaults?: ThreadDefaults,
-
-    threadFetchParams?: ThreadFetchParams,
-};
+import {
+    DeepCopy,
+} from "../../util/common";
 
 export class ThreadController {
-    protected params: ThreadControllerParams;
+    protected threadTemplate: ThreadTemplate;
+
+    protected threadFetchParams: ThreadFetchParams;
+
     protected service: Service;
+
+    protected autoFetchers: AutoFetch[] = [];
+
     protected thread: Thread;
-    protected threadName: string;
+
     protected handlers: {[name: string]: ( (...args: any) => void)[]} = {};
+
     protected isClosed: boolean = false;
+
     protected threadStreamResponseAPI: ThreadStreamResponseAPI;
+
+    protected purgeInterval: number;
+
     protected purgeTimer?: ReturnType<typeof setInterval>;
 
-    constructor(params: ThreadControllerParams, service: Service,
+    /**
+     * @param service the Service object needed to communicate with storage and to sync from peers
+     * @param threadTemplate the ThreadTemplate of the Thred the controller will instantiate
+     * @param threadFetchParams the parameters to override the template with
+     * @param autoSync if true then automatically initiate sync fetch operations via the Service,
+     * default is true.
+     * @param purgeInterval how often in milliseconds to run a purge over old data to be
+     * garbage collected, default is 60000 milliseconds.
+     */
+    constructor(service: Service, threadTemplate: ThreadTemplate,
+        threadFetchParams: ThreadFetchParams = {},
+        autoSync: boolean = true,
         purgeInterval: number = 60_000)
     {
-        if (!params.threadName) {
-            throw new Error("ThreadControllerParams.threadName must be provided to controller");
+        this.service            = service;
+        this.threadTemplate     = threadTemplate;
+        this.threadFetchParams  = threadFetchParams;
+        this.purgeInterval      = purgeInterval;
+
+        const storageClient = service.getStorageClient();
+
+        if (!storageClient) {
+            throw new Error("Missing storageClient in Service");
         }
 
-        this.params     = params;
-        this.service    = service;
-        this.threadName = params.threadName;
+        this.thread = new Thread(threadTemplate, threadFetchParams,
+            storageClient, service.getNodeUtil(), service.getPublicKey(),
+            service.getSignerPublicKey());
 
-        this.thread = this.service.makeThread(this.threadName, params.threadDefaults ?? {});
+        if (autoSync) {
+            this.addAutoSync();
+        }
 
-        // Note that when we set includeLicenses=3 the Storage will automatically add relevent licenses
-        // to the response and also automatically request licenses to be extended for data matched.
-        // This is a more fine grained approach in requesting licenses than using
-        // query.embed and query.match on licenses.
-        const threadFetchParams = {...params.threadFetchParams};
-        threadFetchParams.query = threadFetchParams.query ?? {};
-        threadFetchParams.query.includeLicenses = 3;
-        this.service.addThreadSync(this.thread, threadFetchParams);
-
-        this.threadStreamResponseAPI = this.thread.stream(params.threadFetchParams);
+        this.threadStreamResponseAPI = this.thread.stream();
 
         this.threadStreamResponseAPI.onChange((...args) => this.handleCRDTViewOnChange(...args))
             .onCancel(() => this.close());
 
         if (purgeInterval) {
-            this.purgeTimer = setInterval( () => this.purge(), purgeInterval);
+            this.purgeTimer = setTimeout( () => this.purge(), purgeInterval);
         }
+    }
+
+    /**
+     * Create auto sync configurations and pass them to the Service object.
+     *
+     * @param fetchRequest deriving classes can optionally set this to override the thread template
+     * fetch request
+     * @param fetchRequestReverse deriving class can optionally set this to override the thread
+     * template fetch request for the reverse-fetch, that is what is pushed to remote peer(s).
+     */
+    protected addAutoSync(fetchRequest?: FetchRequest, fetchRequestReverse?: FetchRequest) {
+        this.removeAutoSync();
+
+        fetchRequest = fetchRequest ? DeepCopy(fetchRequest) as FetchRequest :
+            this.thread.getFetchRequest(true);
+
+        // Note that when we set includeLicenses=3 the Storage will automatically
+        // add relevent licenses to the response and also automatically request licenses
+        // to be extended for data matched.
+        // This is a more fine grained approach in requesting licenses than using
+        // query.embed and query.match on licenses.
+        //
+        fetchRequest.query.includeLicenses = 3;
+
+        // Not relevant/allowed for auto fetch.
+        //
+        fetchRequest.query.preserveTransient = false;
+        fetchRequest.crdt.algo = 0;
+
+        const autoFetch: AutoFetch = {
+            fetchRequest,
+            remotePublicKey: Buffer.alloc(0),
+            blobSizeMaxLimit: -1,
+            reverse: false,
+        };
+
+        this.service.addAutoFetch(autoFetch);
+
+        this.autoFetchers.push(autoFetch);
+
+
+        fetchRequestReverse = fetchRequestReverse ? DeepCopy(fetchRequestReverse) as FetchRequest :
+            this.thread.getFetchRequest(true);
+
+        fetchRequestReverse.query.includeLicenses = 3;
+        fetchRequestReverse.query.preserveTransient = false;
+        fetchRequestReverse.crdt.algo = 0;
+
+        const autoFetchReverse: AutoFetch = {
+            fetchRequest: fetchRequestReverse,
+            remotePublicKey: Buffer.alloc(0),
+            blobSizeMaxLimit: -1,
+            reverse: true,
+        };
+
+        this.service.addAutoFetch(autoFetchReverse);
+
+        this.autoFetchers.push(autoFetchReverse);
+    }
+
+    protected removeAutoSync() {
+        this.autoFetchers.forEach( autoFetch => this.service.removeAutoFetch(autoFetch) );
+        this.autoFetchers = [];
     }
 
     /**
@@ -87,21 +178,28 @@ export class ThreadController {
      *
      */
     protected purge(age: number = 600_000) {
+        delete this.purgeTimer;
+
         this.threadStreamResponseAPI.getCRDTView().purge(age).forEach( (data: any) => {
             this.purgeData(data);
         });
+
+        if (!this.isClosed) {
+            this.purgeTimer = setTimeout( () => this.purge(), this.purgeInterval);
+        }
     }
 
     protected purgeData(data: any) {
         // Do nothing. Override to use to free allocated resources.
     }
 
-    protected handleCRDTViewOnChange(event: CRDTVIEW_EVENT) {
+    protected handleCRDTViewOnChange(addedId1s: Buffer[], updatedId1s: Buffer[],
+        deletedId1s: Buffer[])
+    {
         const added: CRDTViewItem[] = [];
         const updated: CRDTViewItem[] = [];
-        const deleted: Buffer[] = [];
 
-        event.added.forEach( id1 => {
+        addedId1s.forEach( id1 => {
             const node = this.threadStreamResponseAPI.getCRDTView().getNode(id1);
             const data = this.threadStreamResponseAPI.getCRDTView().getData(id1);
 
@@ -116,7 +214,7 @@ export class ThreadController {
             }
         });
 
-        event.updated.forEach( id1 => {
+        updatedId1s.forEach( id1 => {
             const node = this.threadStreamResponseAPI.getCRDTView().getNode(id1);
             const data = this.threadStreamResponseAPI.getCRDTView().getData(id1);
 
@@ -135,8 +233,8 @@ export class ThreadController {
 
         updated.sort( (a, b) => a.index - b.index );
 
-        if (added.length > 0 || updated.length > 0 || event.deleted.length > 0) {
-            this.triggerEvent("change", added, updated, event.deleted);
+        if (added.length > 0 || updated.length > 0 || deletedId1s.length > 0) {
+            this.triggerEvent("change", added, updated, deletedId1s);
         }
     }
 
@@ -285,8 +383,10 @@ export class ThreadController {
         this.isClosed = true;
 
         if (this.purgeTimer) {
-            clearInterval(this.purgeTimer);
+            clearTimeout(this.purgeTimer);
         }
+
+        this.removeAutoSync();
 
         this.threadStreamResponseAPI.stopStream();
 

--- a/src/storage/thread/ThreadController.ts
+++ b/src/storage/thread/ThreadController.ts
@@ -326,7 +326,7 @@ export class ThreadController {
     }
 
     /**
-     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.tail
+     * Sugar over this.threadStreamResponseAPI.getFetchRequest().crdt.tail
      *
      * @returns the current (possibly updated) value of tail.
      */
@@ -335,7 +335,7 @@ export class ThreadController {
     }
 
     /**
-     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.head
+     * Sugar over this.threadStreamResponseAPI.getFetchRequest().crdt.head
      *
      * @returns the current (possibly updated) value of head.
      */
@@ -344,7 +344,7 @@ export class ThreadController {
     }
 
     /**
-     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.cursorId1
+     * Sugar over this.threadStreamResponseAPI.getFetchRequest().crdt.cursorId1
      *
      * @returns the current (possibly updated) value of cursorId1.
      */
@@ -353,7 +353,7 @@ export class ThreadController {
     }
 
     /**
-     * Suger over this.threadStreamResponseAPI.getFetchRequest().crdt.cursorIndex
+     * Sugar over this.threadStreamResponseAPI.getFetchRequest().crdt.cursorIndex
      *
      * @returns the current (possibly updated) value of cursorIndex.
      */

--- a/src/storage/thread/types.ts
+++ b/src/storage/thread/types.ts
@@ -13,6 +13,7 @@ import {
 } from "../../datamodel";
 
 import {
+    FetchRequest,
     FetchResponse,
     FetchQuery,
     FetchCRDT,
@@ -185,12 +186,18 @@ export type ThreadStreamResponseAPI = {
 
     /**
      * Update the running fetch request for this stream.
+     * Only set (non undefined) properties are used to update the FetchRequest.
      */
     updateStream: (updateStreamParams: UpdateStreamParams) => void,
 
     getResponse: () => GetResponse<FetchResponse>,
 
     getCRDTView: () => CRDTView,
+
+    /**
+     * Returns the updated FetchRequest.
+     */
+    getFetchRequest: () => FetchRequest,
 };
 
 /**

--- a/src/storage/thread/types.ts
+++ b/src/storage/thread/types.ts
@@ -131,29 +131,6 @@ export type ThreadLicenseParams = LicenseParams & {
     validSeconds?: number,
 };
 
-/**
- * Default parameters layered on top of template properties but below function parameters.
- */
-export type ThreadDefaults = {
-    /**
-     * Default parentId if parentId/rootNodeId1 if not set in post function params.
-     * If rootNodeId1 is set in query then it has precedence over parentId.
-     */
-    parentId?: Buffer,
-
-    /** Default license targets if not set in postLicense function params. */
-    targets?: Buffer[],
-
-    /** Default data and license expire time in milliseconds, if not set in function params. */
-    expireTime?: number,
-
-    /**
-     * Default data and license valid time in seconds, if not set in function params.
-     * Note that this property is only used if expireTime is not set.
-     */
-    validSeconds?: number,
-};
-
 export type UpdateStreamParams = {
     head?: number,
     tail?: number,
@@ -214,4 +191,9 @@ export type ThreadQueryResponseAPI = {
     onCancel: (cb: () => void) => ThreadQueryResponseAPI,
 
     getResponse: () => GetResponse<FetchResponse>,
+
+    /**
+     * Returns the FetchRequest.
+     */
+    getFetchRequest: () => FetchRequest,
 };

--- a/test/datastreamer/blobstreamer.mocha.ts
+++ b/test/datastreamer/blobstreamer.mocha.ts
@@ -122,7 +122,7 @@ describe("BlobStreamWriter, BlobStreamReader", function() {
 
         storage = new Storage(serverP2pClient, signatureOffloader, driver, blobDriver);
 
-        storage.init();
+        await storage.init();
 
         clientP2pClient = new P2PClient(messaging2, clientProps, serverProps);
 

--- a/test/storage/crdt/crdtview.mocha.ts
+++ b/test/storage/crdt/crdtview.mocha.ts
@@ -4,7 +4,6 @@ import {
 
 import {
     CRDTView,
-    CRDTVIEW_EVENT,
     NodeUtil,
 } from "../../../src";
 
@@ -15,10 +14,6 @@ describe("CRDTView", function() {
         const crdtView = new CRDTView();
 
         const nodeUtil = new NodeUtil();
-
-        //crdtView.onChange( (crdtViewEvents: CRDTVIEW_EVENT) => {
-            //console.log(crdtViewEvents);
-        //});
 
         const node1 = await nodeUtil.createDataNode({
             id1: Buffer.alloc(32).fill(10),

--- a/test/storage/onlineNodes.mocha.ts
+++ b/test/storage/onlineNodes.mocha.ts
@@ -529,7 +529,7 @@ async function initStorageInstance(allowPreserveTransient: boolean = false): Pro
     const storage = new StorageWrapper(p2pClient, signatureOffloader, driver, undefined,
         allowPreserveTransient);
 
-    storage.init();
+    await storage.init();
 
     return {
         signatureOffloader,

--- a/test/storage/storage.mocha.ts
+++ b/test/storage/storage.mocha.ts
@@ -49,7 +49,6 @@ import {
     Hash,
     DeepCopy,
     ThreadTemplate,
-    ThreadDefaults,
     Thread,
     PERMISSIVE_PERMISSIONS,
     PromiseCallback,
@@ -1869,10 +1868,7 @@ function setupTests(config: any) {
             }
         };
 
-        const defaults: ThreadDefaults = {};
-
-
-        const thread = new Thread(threadTemplate, defaults, storageClient, nodeUtil,
+        const thread = new Thread(threadTemplate, {}, storageClient, nodeUtil,
             publicKey, publicKey, secretKey);
 
         let node = await thread.post("hello");
@@ -1987,10 +1983,7 @@ function setupTests(config: any) {
             }
         };
 
-        const defaults: ThreadDefaults = {};
-
-
-        const thread = new Thread(threadTemplate, defaults, storageClient, nodeUtil,
+        const thread = new Thread(threadTemplate, {}, storageClient, nodeUtil,
             publicKey, publicKey, secretKey);
 
         let node = await thread.post("hello");

--- a/test/storage/storage.mocha.ts
+++ b/test/storage/storage.mocha.ts
@@ -140,7 +140,7 @@ describe("Storage: triggers", function() {
 
         storage = new StorageWrapper(p2pClient, signatureOffloader, driver);
 
-        storage.init();
+        await storage.init();
     });
 
     afterEach("Close Storage instance", function() {
@@ -510,7 +510,7 @@ describe("Storage: SQLite WAL-mode", function() {
 
         storage = new StorageWrapper(p2pClient, signatureOffloader, driver, blobDriver);
 
-        storage.init();
+        await storage.init();
 
         config.db = db;
         config.blobDb = blobDb;
@@ -594,7 +594,7 @@ describe.skip("Storage: SQLiteJS WAL-mode", function() {
 
         storage = new StorageWrapper(p2pClient, signatureOffloader, driver, blobDriver);
 
-        storage.init();
+        await storage.init();
 
         config.db = db;
         config.blobDb = blobDb;
@@ -686,7 +686,7 @@ describe("Storage: PostgreSQL REPEATABLE READ mode", function() {
 
         storage = new StorageWrapper(p2pClient, signatureOffloader, driver, blobDriver);
 
-        storage.init();
+        await storage.init();
 
         config.db = db;
         config.blobDb = blobDb;


### PR DESCRIPTION
Mixed PR of bugfixes, improvements and additions.

+ Add explicit serialize/deserialize to RPC
+ Add isClosed state to RPC
+ Add Service close/isClosed functions
+ Add missing chunking of results in QueryProcessor
+ Add preAuth event to rpc/OpenOdin
+ Add proper event handling functions to support multiple handlers in rpc/OpenOdin
+ Allow for mutable FetchRequest in Thread
+ Add getFetchRequest function to return copy of current FetchRequest
+ Add sugar functions to ThreadController
+ Add Service.getNodeUtil() so ThreadController can instantiate the Thread
* Make it possible to use SignatureOffloader single threaded to work in Service Workers
(Chrome extensions manifest v. 3)
* Simplify ThreadController and Thread (not to be confused with processor threads as above)
* Improve OpenOdin RPC (client and server)
* Limit chunk size for P2P auto fetcher/extender
* Properly close RPC channels
* Set protected modifier to OpenOdin RPC server constructor parameters
* Improve isBrowser checks to consider extensions
* Fix bug in Thread about expireTime being too short
* Make Thread to only trigger onChange when something has actually changed
* Update thread types to consider FetchRequest
* Refactor ThreadController onChange to callack with more specific data
* Make addAutoFetch better manage duplicate additions
* Make Storage.init() async
* Simplify CRDT events: ThreadController takes over responsibility for creating AutoFetch
objects and passing those to Service. This also gives ThreadControllers better control
over fetching.
* Update tests
* Improve performance updating CRDT models by narrowing driver lock time
- Remove custom console logger
- Remove Thread defaults parameters
- Remove Service.makeThread()
- Remove Service.addThreadSync()