### PR TITLE
Optimize signature offloader RPC and bugfix QueryProcessor

### DIFF
--- a/src/signatureoffloader/SignatureOffloader.ts
+++ b/src/signatureoffloader/SignatureOffloader.ts
@@ -239,13 +239,9 @@ export class SignatureOffloader implements SignatureOffloaderInterface {
 
                 const worker = this.cryptoWorkers[this.cryptoWorkerIndex];
 
-                if (!worker && this.cryptoWorkerIndex === 0) {
+                if (!worker) {
                     reject("No cryptoWorkers available for signature verification.");
                     return;
-                }
-                else if (!worker) {
-                    this.cryptoWorkerIndex = 0;
-                    continue;
                 }
 
                 this.cryptoWorkerIndex++;

--- a/src/storage/QueryProcessor.ts
+++ b/src/storage/QueryProcessor.ts
@@ -1114,7 +1114,6 @@ export class QueryProcessor {
                         const counter = (group[hashedValue] ?? 0) + 1;
 
                         if (counter > match.limitField.limit) {
-                            state.done = true;
                             continue;
                         }
 


### PR DESCRIPTION
This allows multithreading on the app side for signature verification to offload the browser extension thread. Verification only, signing is still done in the extension.

+ Add optional SignatureOffloader verifier to RPC client

+ Call signatureOffload init during OpenOdin constructor

* Fix too early quit processing limitField in QueryProcessor

* Simplify SignatureOffloader worker verification check

* Make CRDTManager double threaded 