### PR TITLE
Make ThreadController work without using CRDTs

### DIFF
--- a/src/storage/thread/types.ts
+++ b/src/storage/thread/types.ts
@@ -147,6 +147,8 @@ export type ThreadStreamResponseAPI = {
     /** onChange events from the CRDTView model. */
     onChange: (...parameters: Parameters<CRDTView["onChange"]>) => ThreadStreamResponseAPI,
 
+    usesCRDT: () => boolean,
+
     /** Nodes incoming in getResponse.onReply. */
     onData: (cb: (nodes: NodeInterface[]) => void) => ThreadStreamResponseAPI,
 

--- a/src/util/ParseUtil.ts
+++ b/src/util/ParseUtil.ts
@@ -159,7 +159,7 @@ export class ParseUtil {
             const threadTemplate = threadTemplates[name];
 
             const query     = ParseUtil.ParseQuery(threadTemplate.query ?? {});
-            const crdt      = ParseUtil.ParseCRDT(threadTemplate.crdt);
+            const crdt      = ParseUtil.ParseCRDT(threadTemplate.crdt ?? {});
 
             const post: {[name: string]: ThreadDataParams} = {};
 
@@ -874,33 +874,6 @@ export class ParseUtil {
             allowNodeTypes,
             allowAlgos,
             allowReadBlob,
-        };
-    }
-
-    /**
-     * @param AutoFetch as:
-     * {
-     *  remotePublicKey?: hexstring | Buffer,   // undefined or empty string means match ALL public keys.
-     *  query: FetchQuery,
-     *  crdt: FetchCRDT,
-     *  blobSizeMaxLimit?: number,
-     *  reverse?: boolean
-     * }
-     * @returns AutoFetch
-     * @throws on unparseable data
-     */
-    public static ParseConfigAutoFetch(autoFetch: any): AutoFetch {
-        const blobSizeMaxLimit = ParseUtil.ParseVariable("autoFetch blobSizeMaxLimit must be integer, if set", autoFetch.blobSizeMaxLimit, "number", true) ?? -1;
-        const reverse = ParseUtil.ParseVariable("autoFetch reverse must be boolean, if set", autoFetch.reverse, "boolean", true) ?? false;
-        const remotePublicKey = ParseUtil.ParseVariable("autoFetch remotePublicKey must be hex-string or Buffer, if set", autoFetch.remotePublicKey, "hex", true) ?? Buffer.alloc(0);
-        const query = ParseUtil.ParseQuery(autoFetch.query);
-        const crdt = ParseUtil.ParseCRDT(autoFetch.crdt ?? {});
-
-        return {
-            remotePublicKey,
-            fetchRequest: {query, crdt},
-            blobSizeMaxLimit,
-            reverse,
         };
     }
 


### PR DESCRIPTION
This allows the caller to use ThreadControllers with FetchRequests which do not have the crdt property set.

+ Add usesCRDT helper to Thread
* Patch ParseCRDT call in ParseUtil
* Improve various comments
- Remove unused function from ParseUtil