### PR TITLE
Add noop call over RPC to keep browser extension alive

### DIFF
--- a/src/rpc/OpenOdin.ts
+++ b/src/rpc/OpenOdin.ts
@@ -249,8 +249,6 @@ export class OpenOdin {
             const rpc2 = this.rpc.clone(authResponse.handshakeRPCId);
             this.authFactory = new AuthFactoryRPCClient(rpc2);
 
-            console.log("authresponse", authResponse);
-
             try {
                 this.service = new Service(authResponse.applicationConf, authResponse.walletConf,
                     this.signatureOffloader, this.authFactory);

--- a/src/rpc/OpenOdinRPCServer.ts
+++ b/src/rpc/OpenOdinRPCServer.ts
@@ -15,8 +15,13 @@ import {
 } from "../util/RPC";
 
 import {
+    ParseUtil,
+} from "../util/ParseUtil";
+
+import {
     AuthResponse,
     AuthResponse2,
+    AuthRequest,
 } from "./types";
 
 export class OpenOdinRPCServer {
@@ -51,7 +56,7 @@ export class OpenOdinRPCServer {
      * The application is requesting to be authorized.
      * @returns AuthResponse.
      */
-    protected auth = async (): Promise<AuthResponse> => {
+    protected auth = async (authRequest: AuthRequest): Promise<AuthResponse> => {
         if (this.signatureOffloaderRPCServer || this.authFactoryRPCCserver) {
             return {
                 error: "OpenOdinRPCServer already authenticated",
@@ -103,9 +108,15 @@ export class OpenOdinRPCServer {
 
         this.authFactoryRPCCserver = new AuthFactoryRPCServer(rpc2, keyPairs2);
 
+        const applicationConf = authRequest.applicationConf;
+
+        const walletConf = ParseUtil.ParseWalletConf({});
+
         return {
             signatureOffloaderRPCId,
             handshakeRPCId,
+            applicationConf,
+            walletConf,
         };
     }
 }

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -1,3 +1,8 @@
+import {
+    ApplicationConf,
+    WalletConf,
+} from "../service/types";
+
 export type ClientConfig = {
     clientId: string,
     localAddress?: string,
@@ -8,10 +13,16 @@ export type ClientConfig = {
     isTextMode: boolean,
 };
 
+export type AuthRequest = {
+    applicationConf: ApplicationConf,
+};
+
 export type AuthResponse = {
     error?: string,
     signatureOffloaderRPCId?: string,
     handshakeRPCId?: string,
+    applicationConf?: ApplicationConf,
+    walletConf?: WalletConf,
 };
 
 export type WalletKeyPair = {

--- a/src/service/Service.ts
+++ b/src/service/Service.ts
@@ -517,6 +517,14 @@ export class Service {
         return DeepCopy(this.applicationConf.custom);
     }
 
+    public getWalletConf(): WalletConf {
+        return DeepCopy(this.walletConf);
+    }
+
+    public getApplicationConf(): ApplicationConf {
+        return DeepCopy(this.applicationConf);
+    }
+
     /**
      * Set or remove auth cert.
      * Auth cert will be cryptographically verified, but


### PR DESCRIPTION
+ Foward application json to DataWallet and get return
+ Add Service getWalletConf() and getApplicationConf()
+ Handle freeze event (Chrome-specific from Page Lifecycle API)
* A couple internal OpenOdin data renaming
- Remove OpenOdin.getWalletConf()