### PR TITLE
Fix so that different OpenOdin versions can agree on ser format

### DIFF
--- a/BUMP_VERSION.md
+++ b/BUMP_VERSION.md
@@ -1,13 +1,14 @@
-# How to bump version
+# How to bump OpenOdin version
 
     1. Update CHANGELOG.md
-    2. Update package.json to new version
-    3. Run `npm i` to update package-lock.json
-    4. Run `npm run build` to build
-    5. Run `npm test`
-    6. Run `npx ts-node ./test/integration/chat/Chat.ts`
-    7. Commit changes
-    8. Tag commit with new version
-    9. Push to remote
-    10. Publish to the npm registry
-    11. Done
+    2. Update ./types.ts `Version` field to new version
+    3. Update package.json to new version
+    4. Run `npm i` to update package-lock.json
+    5. Run `npm run build` to build
+    6. Run `npm test`
+    7. Run `npx ts-node ./test/integration/chat/Chat.ts`
+    8. Commit changes
+    9. Tag commit with new version
+    10. Push to remote
+    11. Publish to the npm registry
+    12. Done

--- a/package-lock.json
+++ b/package-lock.json
@@ -1940,12 +1940,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -3114,9 +3114,9 @@
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -8469,12 +8469,12 @@
             }
         },
         "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "requires": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             }
         },
         "brorand": {
@@ -9395,9 +9395,9 @@
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openodin",
-    "version": "0.8.8",
+    "version": "0.8.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openodin",
-            "version": "0.8.8",
+            "version": "0.8.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethereumjs/util": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openodin",
-    "version": "0.8.8",
+    "version": "0.8.9",
     "description": "OpenOdin is the open source database built for interoperable applications",
     "keywords": [
         "decentralized",

--- a/src/datamodel/node/primary/interface/NodeInterface.ts
+++ b/src/datamodel/node/primary/interface/NodeInterface.ts
@@ -3,7 +3,7 @@ import {
 } from "../../../model";
 
 import {
-    Version,
+    NodeVersion,
     NodeParams,
 } from "../node/types";
 
@@ -27,8 +27,8 @@ export interface NodeInterface extends DataModelInterface {
     isOnlineEmbeddingOnline(): boolean;
     setOnlineIdValidated(isValidated?: boolean): void;
     isOnlineIdValidated(): boolean;
-    getBaseVersion(): Version;
-    getVersion(): Version;
+    getBaseVersion(): NodeVersion;
+    getVersion(): NodeVersion;
     hashShared(): Buffer;
     getHashedValue(field: string): string | undefined;
     hash0(): Buffer;

--- a/src/datamodel/node/primary/node/Node.ts
+++ b/src/datamodel/node/primary/node/Node.ts
@@ -20,7 +20,7 @@ import {
 import {
     NodeConfig,
     TransientConfig,
-    Version,
+    NodeVersion,
     NodeParams,
 } from "./types";
 
@@ -527,7 +527,7 @@ export abstract class Node implements NodeInterface {
      * Return this abstract node's version.
      * @returns semver base version of this node.
      */
-    public getBaseVersion(): Version {
+    public getBaseVersion(): NodeVersion {
         return [CLASS_MAJOR_VERSION, CLASS_MINOR_VERSION, CLASS_PATCH_VERSION];
     }
 
@@ -535,7 +535,7 @@ export abstract class Node implements NodeInterface {
      * Return this abstract node's version.
      * @returns semver base version of this node.
      */
-    public static GetBaseVersion(): Version {
+    public static GetBaseVersion(): NodeVersion {
         return [CLASS_MAJOR_VERSION, CLASS_MINOR_VERSION, CLASS_PATCH_VERSION];
     }
 
@@ -543,13 +543,13 @@ export abstract class Node implements NodeInterface {
      * The deriving node must return its version.
      * @returns semver version of this node.
      */
-    public abstract getVersion(): Version;
+    public abstract getVersion(): NodeVersion;
 
     /**
      * The deriving node must return its version.
      * @returns semver version of this node.
      */
-    public static GetVersion(): Version {
+    public static GetVersion(): NodeVersion {
         throw new Error("Not implemented");
     }
 

--- a/src/datamodel/node/primary/node/types.ts
+++ b/src/datamodel/node/primary/node/types.ts
@@ -24,7 +24,7 @@ export type MinorVersion = number;          // not encoded into data structure
 export type PatchVersion = number;          // not encoded into data structure
 
 /** major, minor, patch */
-export type Version = [MajorVersion, MinorVersion, PatchVersion];
+export type NodeVersion = [MajorVersion, MinorVersion, PatchVersion];
 
 export type NodeParams = {
     modelType?: Buffer,

--- a/src/datamodel/node/secondary/data/Data.ts
+++ b/src/datamodel/node/secondary/data/Data.ts
@@ -27,7 +27,7 @@ import {
 } from "../../primary/node/Node";
 
 import {
-    Version,
+    NodeVersion,
 } from "../../primary/node/types";
 
 import {
@@ -179,7 +179,7 @@ export class Data extends Node implements DataInterface {
      * Return this node's version.
      * @returns semver version of this node.
      */
-    public getVersion(): Version {
+    public getVersion(): NodeVersion {
         return [CLASS_MAJOR_VERSION, CLASS_MINOR_VERSION, CLASS_PATCH_VERSION];
     }
 
@@ -187,7 +187,7 @@ export class Data extends Node implements DataInterface {
      * The deriving node must return its version.
      * @returns semver version of this node.
      */
-    public static GetVersion(): Version {
+    public static GetVersion(): NodeVersion {
         return [CLASS_MAJOR_VERSION, CLASS_MINOR_VERSION, CLASS_PATCH_VERSION];
     }
 

--- a/src/datamodel/node/secondary/license/License.ts
+++ b/src/datamodel/node/secondary/license/License.ts
@@ -1,6 +1,6 @@
 import {
     Node,
-    Version,
+    NodeVersion,
 } from "../../primary/node";
 
 import {
@@ -252,7 +252,7 @@ export class License extends Node implements LicenseInterface {
      * Return this node's version.
      * @returns semver version of this node.
      */
-    public getVersion(): Version {
+    public getVersion(): NodeVersion {
         return [CLASS_MAJOR_VERSION, CLASS_MINOR_VERSION, CLASS_PATCH_VERSION];
     }
 
@@ -260,7 +260,7 @@ export class License extends Node implements LicenseInterface {
      * Return this node's version.
      * @returns semver version of this node.
      */
-    public static GetVersion(): Version {
+    public static GetVersion(): NodeVersion {
         return [CLASS_MAJOR_VERSION, CLASS_MINOR_VERSION, CLASS_PATCH_VERSION];
     }
 

--- a/src/p2pclient/PeerData.ts
+++ b/src/p2pclient/PeerData.ts
@@ -112,8 +112,57 @@ export class PeerData {
         this.model.setBuffer("version", version);
     }
 
+    public setVersionFromString(version: string | undefined) {
+        if (version === undefined) {
+            this.model.setBuffer("version", version);
+        }
+        else {
+            const [major, minor, patch] = version.split(".").map(n => parseInt(n));
+
+            const versionBuf = Buffer.alloc(6);
+            versionBuf.writeUInt16BE(major, 0);
+            versionBuf.writeUInt16BE(minor, 2);
+            versionBuf.writeUInt16BE(patch, 4);
+
+            this.model.setBuffer("version", versionBuf);
+        }
+    }
+
     public getVersion(): Buffer | undefined {
         return this.model.getBuffer("version");
+    }
+
+    /**
+     * Compare stored version with given.
+     * @param version to compare with, semver format as "x.y.z"
+     * @returns -1 if stored version is lesser, 0 if same, 1 if stored version is greater.
+     */
+    public cmpVersion(version: string): number {
+        const [major, minor, patch] = version.split(".").map(n => parseInt(n));
+
+        if (this.getMajorVersion() < major) {
+            return -1;
+        }
+        else if (this.getMajorVersion() > major) {
+            return 1;
+        }
+
+        if (this.getMinorVersion() < minor) {
+            return -1;
+        }
+        else if (this.getMinorVersion() > minor) {
+            return 1;
+        }
+
+
+        if (this.getPatchVersion() < patch) {
+            return -1;
+        }
+        else if (this.getPatchVersion() > patch) {
+            return 1;
+        }
+
+        return 0;
     }
 
     public getMajorVersion(): number {
@@ -136,6 +185,16 @@ export class PeerData {
         return version.readUInt16BE(2);
     }
 
+    public getPatchVersion(): number {
+        const version = this.getVersion();
+
+        if (!version) {
+            return 0;
+        }
+
+        return version.readUInt16BE(4);
+    }
+
     public setSerializeFormat(format: number | undefined) {
         this.model.setNumber("serializeFormat", format);
     }
@@ -146,6 +205,22 @@ export class PeerData {
 
     public setAppVersion(appVersion: Buffer | undefined) {
         this.model.setBuffer("appVersion", appVersion);
+    }
+
+    public setAppVersionFromString(appVersion: string | undefined) {
+        if (appVersion === undefined) {
+            this.model.setBuffer("appVersion", appVersion);
+        }
+        else {
+            const [major, minor, patch] = appVersion.split(".").map(n => parseInt(n));
+
+            const versionBuf = Buffer.alloc(6);
+            versionBuf.writeUInt16BE(major, 0);
+            versionBuf.writeUInt16BE(minor, 2);
+            versionBuf.writeUInt16BE(patch, 4);
+
+            this.model.setBuffer("appVersion", versionBuf);
+        }
     }
 
     public getAppVersion(): Buffer | undefined {

--- a/src/p2pclient/PeerDataUtil.ts
+++ b/src/p2pclient/PeerDataUtil.ts
@@ -30,7 +30,8 @@ export class PeerDataUtil {
     public static create(params: PeerDataParams): PeerData {
         const peerData = new PeerData();
 
-        peerData.setVersion(params.version);
+        peerData.setVersionFromString(params.version);
+
         peerData.setSerializeFormat(params.serializeFormat);
         if (params.handshakePublicKey) {
             peerData.setHandshakePublicKey(params.handshakePublicKey);
@@ -49,7 +50,7 @@ export class PeerDataUtil {
 
         peerData.setRegion(params.region);
         peerData.setJurisdiction(params.jurisdiction);
-        peerData.setAppVersion(params.appVersion);
+        peerData.setAppVersionFromString(params.appVersion);
         peerData.setExpireTime(params.expireTime);
 
         return peerData;

--- a/src/p2pclient/types.ts
+++ b/src/p2pclient/types.ts
@@ -51,7 +51,7 @@ export const Formats: {[id: string]: Format} = {
         id: 0,
         name: "bebop",
         description: "Standard Bebop binary serialization",
-        fromVersion: "0.9.0",
+        fromVersion: "0.8.9",
     },
 };
 

--- a/src/p2pclient/types.ts
+++ b/src/p2pclient/types.ts
@@ -21,6 +21,40 @@ export enum RouteAction {
 export type SerializeInterface<DataType> = (data: DataType) => Buffer;
 export type DeserializeInterface<DataType> = (serialized: Buffer) => DataType;
 
+/**
+ * Type of a serialization format supported by OpenOdin.
+ * Both peers must use the same serialization format.
+ */
+export type Format = {
+    /** ID, 0-255 */
+    id: number,
+
+    /** Name of Format */
+    name: string,
+
+    /** Short description */
+    description: string,
+
+    /** In which OpenOdin version was this format added */
+    fromVersion: string,
+
+    /** UNIX time (in seconds) for when this format expires and no longer can be used, if ever */
+    expires?: number,
+};
+
+/**
+ * The list of formats is an append-only list.
+ * Formats which are no longer supported can be removed but their ID must not be reused.
+ */
+export const Formats: {[id: string]: Format} = {
+    0: {
+        id: 0,
+        name: "bebop",
+        description: "Standard Bebop binary serialization",
+        fromVersion: "0.9.0",
+    },
+};
+
 /** Internally used struct for keeping track of subscriptions. */
 export type SubscriptionMap = {
     /** fromMsgId is the ID of the message received from a peer. */
@@ -230,7 +264,7 @@ export const LOCKED_PERMISSIONS: P2PClientPermissions = {
 };
 
 export type PeerDataParams = {
-    version?: Buffer,
+    version: string,
     serializeFormat: number,
     handshakePublicKey?: Buffer,
     authCert?: Buffer,
@@ -238,6 +272,6 @@ export type PeerDataParams = {
     clockDiff?: number,
     region?: string,
     jurisdiction?: string,
-    appVersion?: Buffer,
+    appVersion?: string,
     expireTime?: number,
 };

--- a/src/rpc/OpenOdin.ts
+++ b/src/rpc/OpenOdin.ts
@@ -41,6 +41,10 @@ import {
     ParseUtil,
 } from "../util";
 
+import {
+    Version,
+} from "../types";
+
 declare const window: any;
 
 /**
@@ -268,7 +272,7 @@ export class OpenOdin {
             catch(e) {
                 console.error(e);
 
-                this.triggerEvent("authFail",`Could not init Service: ${e}`);
+                this.triggerEvent("authFail", `Could not init Service: ${e}`);
 
                 this.close();
 
@@ -313,6 +317,37 @@ export class OpenOdin {
 
     public getService = (): Service | undefined => {
         return this.service;
+    }
+
+    /**
+     * @returns the OpenOdin version
+     */
+    public getVersion(): string {
+        return Version;
+    }
+
+    /**
+     * @returns the application version as given in the ApplicationConf
+     */
+    public getAppVersion(): string {
+        return this.applicationConf.version;
+    }
+
+    /**
+     * Returns information about the remote DataWallet.
+     *
+     * @returns {
+     *  version: <OpenOdin version of DataWallet>,
+     *  appVersion: <version of the DataWallet>,
+     *  name: "OpenOdin DataWallet (official)",
+     * }
+     */
+    public getRemoteInfo = async (): Promise<string | undefined> => {
+        if (this._isClosed || !this._isOpened) {
+            return undefined;
+        }
+
+        return this.rpc.call("getInfo");
     }
 
     /**

--- a/src/rpc/OpenOdinRPCServer.ts
+++ b/src/rpc/OpenOdinRPCServer.ts
@@ -26,7 +26,12 @@ import {
     AuthResponse,
     AuthResponse2,
     AuthRequest,
+    RemoteInfo,
 } from "./types";
+
+import {
+    Version,
+} from "../types";
 
 export class OpenOdinRPCServer {
     protected triggerOnAuth?: (rpcId1: string, rpcId2: string) => Promise<AuthResponse2>;
@@ -35,9 +40,21 @@ export class OpenOdinRPCServer {
     protected settingsManagerRPCServer?: SettingsManagerRPCServer;
 
     constructor(protected rpc: RPC, protected nrOfWorkers: number = 1,
-        protected singleThreaded: boolean = false)
+        protected singleThreaded: boolean = false,
+        protected appName: string,
+        protected appVersion: string)
     {
         this.rpc.onCall("auth", this.auth);
+
+        this.rpc.onCall("getInfo", async () => {
+            const info: RemoteInfo = {
+                version: Version,
+                appVersion: this.appVersion,
+                name: this.appName,
+            };
+
+            return info;
+        });
 
         this.rpc.onCall("noop", async () => {
             return "noop";

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -13,6 +13,12 @@ export type ClientConfig = {
     isTextMode: boolean,
 };
 
+export type RemoteInfo = {
+    version: string,
+    appVersion: string,
+    name: string,
+};
+
 export type AuthRequest = {
     applicationConf: ApplicationConf,
 };

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -30,6 +30,18 @@ export type ConnectionConfig = {
     permissions: P2PClientPermissions,
     region?: string,
     jurisdiction?: string,
+
+    /**
+     * If set then dictate the type of serialization used between peers.
+     *
+     * The peer running the oldest OpenOdin version has precedence over
+     * which format to use (defaults to 0 if not set).
+     *
+     * When running the same OpenOdin version the format with the highest number is chosen.
+     *
+     * Must be between 0 and 255 (default is 0).
+     */
+    serializeFormat: number,
 };
 
 export type ExposeStorageToApp = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export {EventType};
  * Semver version of OpenOdin.
  * "major, minor, patch".
  */
-export const Version = "0.9.0";
+export const Version = "0.8.9";
 
 /**
  * Define size of when messages are split into multiple messages.

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,12 @@ import {
 export {EventType};
 
 /**
+ * Semver version of OpenOdin.
+ * "major, minor, patch".
+ */
+export const Version = "0.9.0";
+
+/**
  * Define size of when messages are split into multiple messages.
  * MESSAGE_MAX_BYTES bytes is the max message size allowed in pocket-messaging,
  * the subtraction is to take our own serialization overhead into account.

--- a/test/datastreamer/blobstreamer.mocha.ts
+++ b/test/datastreamer/blobstreamer.mocha.ts
@@ -40,6 +40,7 @@ import {
     BLOB_TABLES,
     Status,
     StreamStatus,
+    Version,
 } from "../../src";
 
 
@@ -290,8 +291,8 @@ describe("BlobStreamWriter, BlobStreamReader", function() {
 
 function makePeerData(publicKey: Buffer): PeerData {
     return PeerDataUtil.create({
-        version: P2PClient.Version,
-        serializeFormat: P2PClient.Formats[0],
+        version: Version,
+        serializeFormat: 0,
         handshakePublicKey: publicKey,
         authCert: undefined,
         authCertPublicKey: undefined,

--- a/test/integration/chat/client-conf.json
+++ b/test/integration/chat/client-conf.json
@@ -1,6 +1,6 @@
 {
     "name": "chat",
-    "version": "0.1",
+    "version": "0.1.0",
     "threads": {
         "channel": {
             "query": {

--- a/test/integration/chat/server-conf.json
+++ b/test/integration/chat/server-conf.json
@@ -1,6 +1,6 @@
 {
     "name": "chat-server",
-    "version": "0.1",
+    "version": "0.1.0",
     "threads": {
         "channel": {
             "query": {

--- a/test/storage/onlineNodes.mocha.ts
+++ b/test/storage/onlineNodes.mocha.ts
@@ -39,6 +39,7 @@ import {
     NodeInterface,
     Decoder,
     sleep,
+    Version,
 } from "../../src";
 
 type StorageInstance = {
@@ -562,8 +563,8 @@ function closeStorageInstance(s: StorageInstance) {
 
 function makePeerData(): PeerData {
     return PeerDataUtil.create({
-        version: P2PClient.Version,
-        serializeFormat: P2PClient.Formats[0],
+        version: Version,
+        serializeFormat: 0,
         authCert: undefined,
         authCertPublicKey: undefined,
         clockDiff: 0,

--- a/test/storage/storage.mocha.ts
+++ b/test/storage/storage.mocha.ts
@@ -54,6 +54,7 @@ import {
     PromiseCallback,
     SPECIAL_NODES,
     CRDTMessagesAnnotations,
+    Version,
 } from "../../src";
 
 export class StorageWrapper extends Storage {
@@ -2066,8 +2067,8 @@ function setupTests(config: any) {
 
 function makePeerData(): PeerData {
     return PeerDataUtil.create({
-        version: P2PClient.Version,
-        serializeFormat: P2PClient.Formats[0],
+        version: Version,
+        serializeFormat: 0,
         authCert: undefined,
         authCertPublicKey: undefined,
         clockDiff: 0,


### PR DESCRIPTION
Attempt to adapt to newest serialization format while managing fallback to older alternative.

+ P2PClient logic to handle different OpenOdin versions and serialization formats
+ Add version related utility functions to PeerData
+ Add Version and Formats constants
+ Add getRemoteInfo RPC call
+ Add getVersion and getAppVersion to OpenOdin RPC
+ Add serializeFormat field to ConnectionConfig and ParseUtil
* Refactor Version type in datamodel to NodeVersion
* Change OpenOdinServer constructor to take app name and version as constructor parameter
* Simplify Service makePeerData
* Update tests
* Update BUMP_VERSION.md to include ./types.ts instruction
* Bump braces package indirect dependency to address