### PR TITLE
Fix array.sort usage to work properly with number elements

### DIFF
--- a/src/p2pclient/P2PClientForwarder.ts
+++ b/src/p2pclient/P2PClientForwarder.ts
@@ -290,7 +290,7 @@ export class P2PClientForwarder {
 
         this.subscriptionMaps.length = 0;
 
-        muteMsgIdsIndex.sort().reverse();
+        muteMsgIdsIndex.sort( (a, b) => b - a );  // reversed
 
         muteMsgIdsIndex.forEach( index => this.muteMsgIds.splice(index, 1) );
     }

--- a/src/storage/crdt/AlgoRefId.ts
+++ b/src/storage/crdt/AlgoRefId.ts
@@ -347,7 +347,7 @@ export class AlgoRefId implements AlgoInterface {
 
     public delete(indexes: number[]) {
         indexes = indexes.slice();  // copy it
-        indexes.sort();
+        indexes.sort( (a, b) => a - b );
 
         while (indexes.length > 0) {
             const index = indexes.pop();

--- a/src/storage/crdt/AlgoSorted.ts
+++ b/src/storage/crdt/AlgoSorted.ts
@@ -302,7 +302,7 @@ export class AlgoSorted implements AlgoInterface {
 
     public delete(indexes: number[]) {
         indexes = indexes.slice();  // copy it
-        indexes.sort();
+        indexes.sort( (a, b) => a - b );
 
         while (indexes.length > 0) {
             const index = indexes.pop();

--- a/src/storage/crdt/AlgoSortedRefId.ts
+++ b/src/storage/crdt/AlgoSortedRefId.ts
@@ -351,7 +351,7 @@ export class AlgoSortedRefId implements AlgoInterface {
 
     public delete(indexes: number[]) {
         indexes = indexes.slice();  // copy it
-        indexes.sort();
+        indexes.sort( (a, b) => a - b );
 
         while (indexes.length > 0) {
             const index = indexes.pop();


### PR DESCRIPTION
Array.sort() sorts elements as if they are strings, which makes arrays of numbers not properly sorted when calling sort() without arguments.