### PR TITLE
Protect against overflow in fetch response and read blob

### DIFF
--- a/src/p2pclient/GetResponse.ts
+++ b/src/p2pclient/GetResponse.ts
@@ -109,7 +109,7 @@ export class GetResponse<ResponseDataType> {
     /**
      *
      * @param limit optional limit which makes sense for certain ResponseDataTypes.
-     *  For FetchResponse limit detects errornous overflows in resultsets.
+     *  For FetchResponse limit detects erroneous overflows in resultsets.
      */
     constructor(eventEmitter: EventEmitter, msgId: Buffer, serializeResponse: SerializeInterface<ResponseDataType> | undefined, deserializeResponse: DeserializeInterface<ResponseDataType>, p2pClient: P2PClient, isStream: boolean = false, isMultipleStream: boolean = false, limit: number = -1) {
         this.eventEmitter = eventEmitter;

--- a/src/p2pclient/P2PClient.ts
+++ b/src/p2pclient/P2PClient.ts
@@ -49,6 +49,10 @@ import {
 } from "./types";
 
 import {
+    MAX_QUERY_ROWS_LIMIT,
+} from "../storage/types";
+
+import {
     PeerData,
 } from "./PeerData";
 
@@ -959,8 +963,14 @@ export class P2PClient {
             }
 
             // If subscription then we are expecting multiple responses.
+            //
             const isMultipleStream = fetchRequest.query.triggerNodeId.length > 0 || fetchRequest.query.triggerInterval > 0;
-            const getResponse = new GetResponse<FetchResponse>(sendReturn.eventEmitter, sendReturn.msgId, this.serialize.FetchResponse, this.deserialize.FetchResponse, this, isStream, isMultipleStream);
+
+            const limit = fetchRequest.query.limit > -1 ? fetchRequest.query.limit : MAX_QUERY_ROWS_LIMIT;
+
+            const getResponse = new GetResponse<FetchResponse>(sendReturn.eventEmitter, sendReturn.msgId, this.serialize.FetchResponse, this.deserialize.FetchResponse, this, isStream, isMultipleStream,
+                limit);
+
             return {getResponse, msgId: sendReturn.msgId};
         }
         catch(e) {

--- a/src/p2pclient/P2PClientAutoFetcher.ts
+++ b/src/p2pclient/P2PClientAutoFetcher.ts
@@ -280,7 +280,7 @@ export class P2PClientAutoFetcher {
                         if (blobSizeMaxLimit < 0 ||
                             (blobSizeMaxLimit > 0 && blobSizeMaxLimit >= blobSize)) {
 
-                            this.syncBlob(id1);
+                            this.syncBlob(id1, blobSize);
                         }
                     }
                 }
@@ -300,10 +300,11 @@ export class P2PClientAutoFetcher {
      * Attempt to sync a blob from the peer.
      *
      * @param nodeId1 the ID1 of the node who's blob we want to sync and save to the storage.
+     * @param expectedLength set to blob size to protect against overflow.
      * @param retry if true then retry forever
      * @returns Promise which resolves with boolean true when blob is stored to storage.
      */
-    public syncBlob(nodeId1: Buffer, retry: boolean = true):
+    public syncBlob(nodeId1: Buffer, expectedLength: bigint = -1n, retry: boolean = true):
         {promise: Promise<boolean>, streamWriter: StreamWriterInterface} {
 
         const nodeId1Str = nodeId1.toString("hex");
@@ -322,7 +323,7 @@ export class P2PClientAutoFetcher {
             // When fetching in normal we do not want to trigger the muteMsgIds.
             this.muteMsgIds;
 
-        const blobReader = new BlobStreamReader(nodeId1, [this.serverClient]);
+        const blobReader = new BlobStreamReader(nodeId1, [this.serverClient], expectedLength);
 
         const streamWriter = new BlobStreamWriter(nodeId1, blobReader,
             this.storageClient, /*allowResume=*/true, muteMsgIds);

--- a/src/service/Service.ts
+++ b/src/service/Service.ts
@@ -1629,7 +1629,7 @@ export class Service {
      *
      * @returns Generator witch return type {promise: Promise<boolean>, streamWriter: StreamWriterInterface}.
      */
-    public *syncBlob(nodeId1: Buffer) {
+    public *syncBlob(nodeId1: Buffer, expectedLength: bigint = -1n) {
 
         // First check if any AutoFetcher is already syncing.
         for (let i=0; i<this.state.autoFetchers.length; i++) {
@@ -1657,7 +1657,7 @@ export class Service {
                 continue;
             }
 
-            yield autoFetcher.syncBlob(nodeId1, false);
+            yield autoFetcher.syncBlob(nodeId1, expectedLength, false);
         }
     }
 

--- a/src/storage/thread/Thread.ts
+++ b/src/storage/thread/Thread.ts
@@ -688,12 +688,6 @@ export class Thread {
     }
 
     /**
-     * @param expectedLength optionally set this to the lenght of the blob to protected
-     * against overflow.
-     * @returns StreamReaderInterface for reading blob data.
-     */
-
-    /**
      * Helper function to get a StreamReader to stream a blob from storage.
      *
      * @param nodeId1

--- a/src/storage/thread/Thread.ts
+++ b/src/storage/thread/Thread.ts
@@ -688,10 +688,22 @@ export class Thread {
     }
 
     /**
+     * @param expectedLength optionally set this to the lenght of the blob to protected
+     * against overflow.
      * @returns StreamReaderInterface for reading blob data.
      */
-    public getBlobStreamReader(nodeId1: Buffer): StreamReaderInterface {
-        return new BlobStreamReader(nodeId1, [this.storageClient]);
+
+    /**
+     * Helper function to get a StreamReader to stream a blob from storage.
+     *
+     * @param nodeId1
+     * @param expectedLength optionally set this to the lenght of the blob to protected
+     * against overflow.
+     * @returns StreamReaderInterface for reading blob data.
+     * @throws on error
+     */
+    public getBlobStreamReader(nodeId1: Buffer, expectedLength: bigint = -1n): StreamReaderInterface {
+        return new BlobStreamReader(nodeId1, [this.storageClient], expectedLength);
     }
 
     /**

--- a/src/util/StorageUtil.ts
+++ b/src/util/StorageUtil.ts
@@ -170,12 +170,13 @@ export class StorageUtil {
      * Helper function to get a StreamReader to stream a blob from storage.
      *
      * @param nodeId1
-     * @returns streamReader
+     * @param expectedLength optionally set this to the lenght of the blob to protected
+     * against overflow.
+     * @returns StreamReaderInterface for reading blob data.
      * @throws on error
      */
-    public getBlobStreamReader(nodeId1: Buffer): StreamReaderInterface {
-        const streamReader = new BlobStreamReader(nodeId1, [this.storageClient]);
-        return streamReader;
+    public getBlobStreamReader(nodeId1: Buffer, expectedLength: bigint = -1n): StreamReaderInterface {
+        return new BlobStreamReader(nodeId1, [this.storageClient], expectedLength);
     }
 
     /**


### PR DESCRIPTION
Put in place protection to guard againt malicious peer trying to overflow other peer with too large fetch response or too large read blob response. This adds an optional limit parameter to GetResponse.