### PR TITLE
Add permissions control to RPC calls

### DIFF
--- a/src/rpc/AuthFactoryRPCServer.ts
+++ b/src/rpc/AuthFactoryRPCServer.ts
@@ -34,17 +34,19 @@ export class AuthFactoryRPCServer {
     protected rpc: RPC;
     protected keyPairs: KeyPair[];
     protected handshakeFactories: HandshakeFactoryInterface[] = [];
+    protected triggerOnCreate?: (authFactoryConfig: AuthFactoryConfig) => Promise<boolean>;
 
-    constructor(rpc: RPC, keyPairs: KeyPair[]) {
+    constructor(rpc: RPC, keyPairs: KeyPair[], triggerOnCreate?: (authFactoryConfig: AuthFactoryConfig) => Promise<boolean>) {
         this.rpc = rpc;
         this.keyPairs = keyPairs;
+        this.triggerOnCreate = triggerOnCreate;
 
         this.rpc.onCall("create", async (authFactoryConfig: AuthFactoryConfig) => {
+            // User must confirm connection parameters of authFactoryConfig.
             //
-            // Note:
-            // At this point we can pop a modal dialog to confirm the parameters of authFactoryConfig,
-            // or to complement or override the parameters.
-            //
+            if (this.triggerOnCreate && ! (await this.triggerOnCreate(authFactoryConfig))) {
+                return undefined;
+            }
 
             if (this.isNativeHandshake(authFactoryConfig)) {
                 return this.createNativeHandshakeFactory(authFactoryConfig as unknown as

--- a/src/rpc/OpenOdin.ts
+++ b/src/rpc/OpenOdin.ts
@@ -153,6 +153,8 @@ export class OpenOdin {
         });
 
         this.rpc = new RPC(postMessage2, listenMessage, rpcId);
+
+        this.rpc.onCall("attentionNeeded", (count: number) => this.triggerEvent("attentionNeeded", count) );
     }
 
     /**
@@ -422,6 +424,14 @@ export class OpenOdin {
      */
     public onAuthFail = ( cb: (error: string) => void ) => {
         this.hookEvent("authFail", cb);
+    }
+
+    /**
+     * Event triggered by DataWallet when the user's attention is needed
+     * by the DataWallet.
+     */
+    public onAttentionNeeded = ( cb: (count: number) => void ) => {
+        this.hookEvent("attentionNeeded", cb);
     }
 
     /**

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -178,6 +178,8 @@ export type ServicePeerConnectCallback = (p2pClient: P2PClient) => void;
 export type ServicePeerFactoryCreateCallback =
     (handshakeFactory: HandshakeFactoryInterface) => void;
 
+export type ServicePeerFactoryCreateErrorCallback = (error: Error) => void;
+
 export type ServicePeerParseErrorCallback = (error: Error) => void;
 
 export type ServicePeerAuthCertErrorCallback = (error: Error, authCert: Buffer) => void;
@@ -196,6 +198,8 @@ export type ServiceStorageConnectCallback = (p2pClient: P2PClient) => void;
  */
 export type ServiceStorageFactoryCreateCallback = (handshakeFactory: HandshakeFactoryInterface) => void;
 
+export type ServiceStorageFactoryCreateErrorCallback = (error: Error) => void;
+
 export type ServiceStorageParseErrorCallback = (error: Error) => void;
 
 export type ServiceStorageAuthCertErrorCallback = (error: Error, authCert: Buffer) => void;
@@ -208,9 +212,10 @@ export const EVENT_SERVICE_STORAGE_CONNECT = "SERVICE_STORAGE_CONNECT";
 export const EVENT_SERVICE_STORAGE_FACTORY_CREATE = "SERVICE_STORAGE_FACTORY_CREATE";
 export const EVENT_SERVICE_STORAGE_AUTHCERT_ERROR = "SERVICE_STORAGE_AUTHCERT_ERROR";
 export const EVENT_SERVICE_STORAGE_PARSE_ERROR = "SERVICE_STORAGE_PARSE_ERROR";
+export const EVENT_SERVICE_STORAGE_FACTORY_CREATE_ERROR = "SERVICE_STORAGE_FACTORY_CREATE_ERROR";
 export const EVENT_SERVICE_PEER_FACTORY_CREATE = "SERVICE_PEER_FACTORY_CREATE";
 export const EVENT_SERVICE_PEER_CONNECT = "SERVICE_PEER_CONNECT";
 export const EVENT_SERVICE_PEER_CLOSE = "SERVICE_PEER_CLOSE";
 export const EVENT_SERVICE_PEER_AUTHCERT_ERROR = "SERVICE_PEER_AUTHCERT_ERROR";
 export const EVENT_SERVICE_PEER_PARSE_ERROR = "SERVICE_PEER_PARSE_ERROR";
-export const EVENT_SERVICE_PEER_ERROR = "SERVICE_PEER_ERROR";
+export const EVENT_SERVICE_PEER_FACTORY_CREATE_ERROR = "SERVICE_PEER_FACTORY_CREATE_ERROR";


### PR DESCRIPTION
This allows DataWallet to ask for permissoins about sign and handshake.

+ Add onCreate, onSign and onAttentionNeeded RPC triggers

+ Add new trigger for Service creation error

* Change the way connections are initialized and closed inside Service